### PR TITLE
fixes: TypeORM Issue #70: adjusted entities glob for migrations

### DIFF
--- a/backend/core/src/configs/database.config.ts
+++ b/backend/core/src/configs/database.config.ts
@@ -18,7 +18,7 @@ const DATABASE_SHARED = {
 	autoLoadEntities: true,
 	entities: [
 		path.resolve(process.cwd(), 'dist', '**', '*.entity.js'),
-		path.resolve(process.cwd(), 'node_modules', '@juicyllama', '**', '*.entity.{js,ts}'),
+		path.resolve(process.cwd(), 'node_modules', '@juicyllama', '**', 'dist', '**', '*.entity.js'),
 	],
 	autoLoadMigrations: Env.IsNotProd(), //should be false in live, otherwise long running migration will cause issues with microservices booting up
 	migrations: [path.resolve(process.cwd(), 'dist', 'db', 'migrations', '*.js')],


### PR DESCRIPTION
I found this to fix the [issues](https://github.com/juicyllama/framework/issues/70#issuecomment-1827965304)

Please let me know if this change has unexpected results.

I'm not yet sure of the exact reasoning behind this, but my guess aligns with yours: something to do with glob vs symlinks.