### PR TITLE
fixes: TypeORM Issue #70: added typeorm to pnpm link to fix DI for DataSource from 'typeorm'

### DIFF
--- a/pnpm-link.sh
+++ b/pnpm-link.sh
@@ -36,9 +36,10 @@ pnpm link --global --dir apps/wise
 pnpm link --global --dir apps/wordpress
 pnpm link --global --dir apps/xero-cc
 
-# NestJS
+# NestJS DI
 pnpm link --global --dir node_modules/@nestjs/core
 pnpm link --global --dir node_modules/@nestjs/typeorm
+pnpm link --global --dir node_modules/typeorm
 pnpm link --global --dir node_modules/@nestjs/common
 pnpm link --global --dir node_modules/@nestjs/config
 pnpm link --global --dir node_modules/@nestjs/platform-express


### PR DESCRIPTION
To use NestJS class-based DI we need to ensure that anything that is referenced as a dependency via class is pulled from the same instance of the package.

I believe token-based dependencies won't be affected by this issue.