### PR TITLE
fixes: Modules.isInstalled not working locally #80

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node_modules
 dist
 build
-.npmrc
 .env
 .idea
 yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+shamefully-hoist=true
+node-linker=hoisted

--- a/common/docs/.npmrc
+++ b/common/docs/.npmrc
@@ -1,0 +1,2 @@
+shamefully-hoist=true
+strict-peer-dependencies=false

--- a/common/utils/src/utils/Modules.ts
+++ b/common/utils/src/utils/Modules.ts
@@ -9,7 +9,7 @@ export class Modules {
 
 	static isInstalled(name: string): boolean {
 		try {
-			const p = require.resolve(name)
+			const p = require.resolve(name, { paths: require.main.paths })
 			return !!p
 		} catch (e: any) {
 			const logger = new Logger()
@@ -17,5 +17,4 @@ export class Modules {
 			return false
 		}
 	}
-	
 }

--- a/frontend/core/sandbox/.npmrc
+++ b/frontend/core/sandbox/.npmrc
@@ -1,0 +1,3 @@
+# pnpm-related options
+shamefully-hoist=true
+strict-peer-dependencies=false


### PR DESCRIPTION
@andyslack could you please verify if this fix works for you?

In the long run, I suggest we weigh on maybe moving away from relying on `require` behaviour for this and potentially refactor this into using our own modules registry of some sort.