### PR TITLE
Modules.isInstalled not working locally #80: possible fix

### DIFF
--- a/backend/ai/src/ai/ai.service.ts
+++ b/backend/ai/src/ai/ai.service.ts
@@ -54,9 +54,9 @@ export class AiService {
 			})
 		}
 
-		if (Modules.isInstalled('@juicyllama/app-openai')) {
+		if (Modules.openai.isInstalled) {
 			//@ts-ignore
-			const { OpenaiModule, OpenaiService } = await import('@juicyllama/app-openai')
+			const { OpenaiModule, OpenaiService } = await Modules.openai.load()
 			ai.app_integration_name = AppIntegrationName.openai
 
 			try {

--- a/backend/ai/src/ai/ai.service.ts
+++ b/backend/ai/src/ai/ai.service.ts
@@ -55,7 +55,6 @@ export class AiService {
 		}
 
 		if (Modules.openai.isInstalled) {
-			//@ts-ignore
 			const { OpenaiModule, OpenaiService } = await Modules.openai.load()
 			ai.app_integration_name = AppIntegrationName.openai
 

--- a/backend/app-store/src/modules/installed/preinstall/shopify.service.ts
+++ b/backend/app-store/src/modules/installed/preinstall/shopify.service.ts
@@ -13,7 +13,7 @@ export class ShopifyService {
 	) {}
 
 	async precheckShopify(domain: string, app: App, settings: any, account_id: number): Promise<preInstallCheckResponse> {
-		if (!Modules.isInstalled('@juicyllama/app-shopify')) {
+		if (!Modules.shopify.isInstalled) {
 			return {
 				result: false,
 				error: `Shopify is not installed`,

--- a/backend/app-store/src/modules/installed/preinstall/wordpress.service.ts
+++ b/backend/app-store/src/modules/installed/preinstall/wordpress.service.ts
@@ -12,7 +12,7 @@ export class WordPressService {
 	) {}
 
 	async precheckWordpress(domain: string, app: App, settings: any): Promise<preInstallCheckResponse> {
-		if (!Modules.isInstalled('@juicyllama/app-wordpress')) {
+		if (!Modules.wordpress.isInstalled) {
 			return {
 				result: false,
 				error: `WordPress is not installed`,

--- a/backend/app-store/src/modules/installed/preinstall/wordpress.service.ts
+++ b/backend/app-store/src/modules/installed/preinstall/wordpress.service.ts
@@ -20,11 +20,7 @@ export class WordPressService {
 		}
 
 		try {
-			//@ts-ignore
-			const { WordpressUsersModule, WordpressUsersService, WordpressContext } = await import(
-				//@ts-ignore
-				'@juicyllama/app-wordpress'
-			)
+			const { WordpressUsersModule, WordpressUsersService, WordpressContext } = await Modules.wordpress.load()
 			const wordpressUsersModule = await this.lazyModuleLoader.load(() => WordpressUsersModule)
 			const wordpressUsersService = wordpressUsersModule.get(WordpressUsersService)
 

--- a/backend/billing/src/modules/crons/billing.crons.service.ts
+++ b/backend/billing/src/modules/crons/billing.crons.service.ts
@@ -49,8 +49,8 @@ export class BillingCronService {
 		if (![Enviroment.test].includes(this.configService.get('NODE_ENV'))) {
 			let Bugsnag: any
 
-			if (Modules.isInstalled('@bugsnag/js')) {
-				Bugsnag = require('@bugsnag/js')
+			if (Modules.bugsnag.isInstalled) {
+				Bugsnag = await Modules.bugsnag.load()
 				Bugsnag.addMetadata('cron', {
 					domain: domain,
 				})
@@ -122,8 +122,8 @@ export class BillingCronService {
 		if (![Enviroment.test].includes(this.configService.get('NODE_ENV'))) {
 			let Bugsnag: any
 
-			if (Modules.isInstalled('@bugsnag/js')) {
-				Bugsnag = require('@bugsnag/js')
+			if (Modules.bugsnag.isInstalled) {
+				Bugsnag = await Modules.bugsnag.load()
 				Bugsnag.addMetadata('cron', {
 					domain: domain,
 				})
@@ -214,8 +214,8 @@ export class BillingCronService {
 		if (![Enviroment.test].includes(this.configService.get('NODE_ENV'))) {
 			let Bugsnag: any
 
-			if (Modules.isInstalled('@bugsnag/js')) {
-				Bugsnag = require('@bugsnag/js')
+			if (Modules.bugsnag.isInstalled) {
+				Bugsnag = await Modules.bugsnag.load()
 				Bugsnag.addMetadata('cron', {
 					domain: domain,
 				})
@@ -277,8 +277,8 @@ export class BillingCronService {
 		if (![Enviroment.test].includes(this.configService.get('NODE_ENV'))) {
 			let Bugsnag: any
 
-			if (Modules.isInstalled('@bugsnag/js')) {
-				Bugsnag = require('@bugsnag/js')
+			if (Modules.bugsnag.isInstalled) {
+				Bugsnag = await Modules.bugsnag.load()
 				Bugsnag.addMetadata('cron', {
 					domain: domain,
 				})
@@ -359,8 +359,8 @@ export class BillingCronService {
 		if (![Enviroment.test].includes(this.configService.get('NODE_ENV'))) {
 			let Bugsnag: any
 
-			if (Modules.isInstalled('@bugsnag/js')) {
-				Bugsnag = require('@bugsnag/js')
+			if (Modules.bugsnag.isInstalled) {
+				Bugsnag = await Modules.bugsnag.load()
 				Bugsnag.addMetadata('cron', {
 					domain: domain,
 				})
@@ -430,8 +430,8 @@ export class BillingCronService {
 		if (![Enviroment.test].includes(this.configService.get('NODE_ENV'))) {
 			let Bugsnag: any
 
-			if (Modules.isInstalled('@bugsnag/js')) {
-				Bugsnag = require('@bugsnag/js')
+			if (Modules.bugsnag.isInstalled) {
+				Bugsnag = await Modules.bugsnag.load()
 				Bugsnag.addMetadata('cron', {
 					domain: domain,
 				})

--- a/backend/billing/src/modules/invoices/invoices.service.ts
+++ b/backend/billing/src/modules/invoices/invoices.service.ts
@@ -69,7 +69,6 @@ export class InvoicesService extends BaseService<T> {
 		if (Modules.xerocc.isInstalled) {
 			this.logger.debug(`[${domain}] Xero installed, create xero invoice for #${invoice.invoice_id}`, invoice)
 
-			//@ts-ignore
 			const { XeroModule, XeroService } = await Modules.xerocc.load()
 
 			try {
@@ -135,7 +134,6 @@ export class InvoicesService extends BaseService<T> {
 		const domain = 'cron::billing::invoices::xeroAddPayment'
 
 		if (Modules.xerocc.isInstalled) {
-			//@ts-ignore
 			const { XeroModule, XeroService } = await Modules.xerocc.load()
 
 			try {

--- a/backend/billing/src/modules/invoices/invoices.service.ts
+++ b/backend/billing/src/modules/invoices/invoices.service.ts
@@ -66,11 +66,11 @@ export class InvoicesService extends BaseService<T> {
 	async xeroCreateInvoice(invoice: T): Promise<T> {
 		const domain = 'cron::billing::invoices::xeroCreateInvoice'
 
-		if (Modules.isInstalled('@juicyllama/app-xero-cc')) {
+		if (Modules.xerocc.isInstalled) {
 			this.logger.debug(`[${domain}] Xero installed, create xero invoice for #${invoice.invoice_id}`, invoice)
 
 			//@ts-ignore
-			const { XeroModule, XeroService } = await import('@juicyllama/app-xero-cc')
+			const { XeroModule, XeroService } = await Modules.xerocc.load()
 
 			try {
 				const xeroModule = await this.lazyModuleLoader.load(() => XeroModule)
@@ -134,9 +134,9 @@ export class InvoicesService extends BaseService<T> {
 	async xeroAddPayment(invoice: T, amount: number): Promise<void> {
 		const domain = 'cron::billing::invoices::xeroAddPayment'
 
-		if (Modules.isInstalled('@juicyllama/app-xero-cc')) {
+		if (Modules.xerocc.isInstalled) {
 			//@ts-ignore
-			const { XeroModule, XeroService } = await import('@juicyllama/app-xero-cc')
+			const { XeroModule, XeroService } = await Modules.xerocc.load()
 
 			try {
 				const xeroModule = await this.lazyModuleLoader.load(() => XeroModule)

--- a/backend/billing/src/modules/payment_methods/payment.methods.service.ts
+++ b/backend/billing/src/modules/payment_methods/payment.methods.service.ts
@@ -137,7 +137,7 @@ export class PaymentMethodsService extends BaseService<T> {
 
 		switch (payment_method.method) {
 			case PaymentMethodType.banktransfer:
-				if (Modules.isInstalled('@juicyllama/app-wise')) {
+				if (Modules.wise.isInstalled) {
 					/*const { MollieModule, MollieService } = await import('@juicyllama/app-mollie')
 					try {
 						const mollieModule = await this.lazyModuleLoader.load(() => MollieModule)
@@ -215,7 +215,7 @@ export class PaymentMethodsService extends BaseService<T> {
 	}
 
 	async bankInstalled(): Promise<boolean> {
-		return Modules.isInstalled('@juicyllama/app-wise')
+		return Modules.wise.isInstalled
 	}
 
 	async mollieAddCard(payment_method: PaymentMethod, description?: string): Promise<PaymentMethod> {
@@ -226,9 +226,9 @@ export class PaymentMethodsService extends BaseService<T> {
 			description: description,
 		})
 
-		if (Modules.isInstalled('@juicyllama/app-mollie')) {
+		if (Modules.mollie.isInstalled) {
 			//@ts-ignore
-			const { MollieModule, MollieService } = await import('@juicyllama/app-mollie')
+			const { MollieModule, MollieService } = await Modules.mollie.load()
 			try {
 				const mollieModule = await this.lazyModuleLoader.load(() => MollieModule)
 				const mollieService = mollieModule.get(MollieService)
@@ -250,9 +250,9 @@ export class PaymentMethodsService extends BaseService<T> {
 
 	async mollieChargeCard(payment_method: T, amount: number): Promise<void> {
 		const domain = 'billing::PaymentMethodsService::mollieChargeCard'
-		if (Modules.isInstalled('@juicyllama/app-mollie')) {
+		if (Modules.mollie.isInstalled) {
 			//@ts-ignore
-			const { MollieModule, MollieService } = await import('@juicyllama/app-mollie')
+			const { MollieModule, MollieService } = await Modules.mollie.load()
 			try {
 				const mollieModule = await this.lazyModuleLoader.load(() => MollieModule)
 				const mollieService = mollieModule.get(MollieService)

--- a/backend/billing/src/modules/payment_methods/payment.methods.service.ts
+++ b/backend/billing/src/modules/payment_methods/payment.methods.service.ts
@@ -227,7 +227,6 @@ export class PaymentMethodsService extends BaseService<T> {
 		})
 
 		if (Modules.mollie.isInstalled) {
-			//@ts-ignore
 			const { MollieModule, MollieService } = await Modules.mollie.load()
 			try {
 				const mollieModule = await this.lazyModuleLoader.load(() => MollieModule)
@@ -251,7 +250,6 @@ export class PaymentMethodsService extends BaseService<T> {
 	async mollieChargeCard(payment_method: T, amount: number): Promise<void> {
 		const domain = 'billing::PaymentMethodsService::mollieChargeCard'
 		if (Modules.mollie.isInstalled) {
-			//@ts-ignore
 			const { MollieModule, MollieService } = await Modules.mollie.load()
 			try {
 				const mollieModule = await this.lazyModuleLoader.load(() => MollieModule)

--- a/backend/core/src/configs/aws.secrets.ts
+++ b/backend/core/src/configs/aws.secrets.ts
@@ -7,7 +7,6 @@ export async function loadEnvVariables(SECRET_MANAGER_NAME: string, envPath: str
 		if (!Modules.aws.isInstalled) {
 			new Error('[loadEnvVariables] AWS Module not installed')
 		}
-		//@ts-ignore
 		const { getSecret } = await Modules.aws.load()
 		const secrets = await getSecret(SECRET_MANAGER_NAME)
 

--- a/backend/core/src/configs/aws.secrets.ts
+++ b/backend/core/src/configs/aws.secrets.ts
@@ -4,11 +4,11 @@ export async function loadEnvVariables(SECRET_MANAGER_NAME: string, envPath: str
 	const logger = new Logger()
 
 	try {
-		if (!Modules.isInstalled('@juicyllama/app-aws')) {
+		if (!Modules.aws.isInstalled) {
 			new Error('[loadEnvVariables] AWS Module not installed')
 		}
 		//@ts-ignore
-		const { getSecret } = await import('@juicyllama/app-aws')
+		const { getSecret } = await Modules.aws.load()
 		const secrets = await getSecret(SECRET_MANAGER_NAME)
 
 		if (!secrets) {

--- a/backend/core/src/middleware/AuthCheck.ts
+++ b/backend/core/src/middleware/AuthCheck.ts
@@ -9,7 +9,6 @@ export class MiddlewareAccountId implements NestMiddleware {
 	constructor(
 		@Inject(forwardRef(() => AccountService)) private readonly accountService: AccountService,
 		@Inject(forwardRef(() => AuthService)) private readonly authService: AuthService,
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
 	) {}
 
 	async use(req: any, res: any, next: NextFunction) {
@@ -21,8 +20,8 @@ export class MiddlewareAccountId implements NestMiddleware {
 			await this.authService.check(req.user.user_id, account_id)
 
 			let Bugsnag: any
-			if (Modules.isInstalled('@bugsnag/js')) {
-				Bugsnag = require('@bugsnag/js')
+			if (Modules.bugsnag.isInstalled) {
+				Bugsnag = Modules.bugsnag.load()
 				Bugsnag.addMetadata('account', await this.accountService.findById(req.query.account_id))
 				Bugsnag.addMetadata('user', req.user)
 			}

--- a/backend/core/src/middleware/AuthCheck.ts
+++ b/backend/core/src/middleware/AuthCheck.ts
@@ -1,6 +1,6 @@
 import { forwardRef, Inject, Injectable, NestMiddleware } from '@nestjs/common'
 import { NextFunction } from 'express'
-import { Logger, Modules } from '@juicyllama/utils'
+import { Modules } from '@juicyllama/utils'
 import { AuthService } from '../modules/auth/auth.service'
 import { AccountService } from '../modules/accounts/account.service'
 

--- a/backend/core/src/modules/auth/auth.service.ts
+++ b/backend/core/src/modules/auth/auth.service.ts
@@ -80,8 +80,8 @@ export class AuthService extends BaseService<T> {
 		const payload = await this.constructLoginPayload(user)
 		if (!['development', 'test'].includes(process.env.NODE_ENV)) {
 			let Bugsnag
-			if (Modules.isInstalled('@bugsnag/js')) {
-				Bugsnag = require('@bugsnag/js')
+			if (Modules.bugsnag.isInstalled) {
+				Bugsnag = Modules.bugsnag.load()
 				Bugsnag.setUser(user.user_id, user.email)
 			}
 		}

--- a/backend/core/src/modules/beacon/email/email.service.ts
+++ b/backend/core/src/modules/beacon/email/email.service.ts
@@ -60,7 +60,7 @@ export class BeaconEmailService {
 
 		if (Modules.isInstalled('@juicyllama/app-aws')) {
 			//@ts-ignore
-			const { AwsSesModule, AwsSesService } = await import('@juicyllama/app-aws')
+			const { AwsSesModule, AwsSesService } = Modules.load('@juicyllama/app-aws')
 
 			try {
 				const awsSesModule = await this.lazyModuleLoader.load(() => AwsSesModule)

--- a/backend/core/src/modules/beacon/email/email.service.ts
+++ b/backend/core/src/modules/beacon/email/email.service.ts
@@ -58,8 +58,8 @@ export class BeaconEmailService {
 
 		let service: any
 
-		if (Modules.appAws.isInstalled) {
-			const { AwsSesModule, AwsSesService } = await Modules.appAws.load()
+		if (Modules.aws.isInstalled) {
+			const { AwsSesModule, AwsSesService } = await Modules.aws.load()
 
 			try {
 				const awsSesModule = await this.lazyModuleLoader.load(() => AwsSesModule)
@@ -88,7 +88,7 @@ export class BeaconEmailService {
 		}
 
 		if (!service) {
-			this.logger.error(`No email app installed, options are: ${Modules.appAws.name}`)
+			this.logger.error(`No email app installed, options are: ${Modules.aws.name}`)
 			return false
 		}
 	}

--- a/backend/core/src/modules/beacon/email/email.service.ts
+++ b/backend/core/src/modules/beacon/email/email.service.ts
@@ -58,9 +58,8 @@ export class BeaconEmailService {
 
 		let service: any
 
-		if (Modules.isInstalled('@juicyllama/app-aws')) {
-			//@ts-ignore
-			const { AwsSesModule, AwsSesService } = Modules.load('@juicyllama/app-aws')
+		if (Modules.appAws.isInstalled) {
+			const { AwsSesModule, AwsSesService } = await Modules.appAws.load()
 
 			try {
 				const awsSesModule = await this.lazyModuleLoader.load(() => AwsSesModule)
@@ -89,7 +88,7 @@ export class BeaconEmailService {
 		}
 
 		if (!service) {
-			this.logger.error(`No email app installed, options are: @juicyllama/app-aws`)
+			this.logger.error(`No email app installed, options are: ${Modules.appAws.name}`)
 			return false
 		}
 	}

--- a/backend/core/src/modules/beacon/im/im.service.ts
+++ b/backend/core/src/modules/beacon/im/im.service.ts
@@ -45,9 +45,9 @@ export class BeaconImService {
 
 		let service: any
 
-		if (Modules.isInstalled('@juicyllama/app-slack')) {
+		if (Modules.slack.isInstalled) {
 			//@ts-ignore
-			const { SlackModule, SlackService } = await import('@juicyllama/app-slack')
+			const { SlackModule, SlackService } = await Modules.slack.load()
 
 			try {
 				const slackModule = await this.lazyModuleLoader.load(() => SlackModule)

--- a/backend/core/src/modules/beacon/im/im.service.ts
+++ b/backend/core/src/modules/beacon/im/im.service.ts
@@ -46,7 +46,6 @@ export class BeaconImService {
 		let service: any
 
 		if (Modules.slack.isInstalled) {
-			//@ts-ignore
 			const { SlackModule, SlackService } = await Modules.slack.load()
 
 			try {

--- a/backend/core/src/modules/beacon/push/push.service.ts
+++ b/backend/core/src/modules/beacon/push/push.service.ts
@@ -50,9 +50,9 @@ export class BeaconPushService {
 		let service: any
 		let app_integration_name: string
 
-		if (Modules.isInstalled('pusher')) {
+		if (Modules.pusher.isInstalled) {
 			app_integration_name = 'pusher'
-			service = require('pusher')
+			service = Modules.pusher.load()
 
 			if (
 				_.isUndefined(this.configService.get<string>('beacon.PUSHER_APP_ID')) ||

--- a/backend/core/src/modules/beacon/sms/sms.service.ts
+++ b/backend/core/src/modules/beacon/sms/sms.service.ts
@@ -50,9 +50,9 @@ export class BeaconSmsService {
 
 		let service: any
 
-		if (Modules.isInstalled('@juicyllama/app-aws')) {
+		if (Modules.aws.isInstalled) {
 			//@ts-ignore
-			const { AwsSnsModule, AwsSnsService } = await import('@juicyllama/app-aws')
+			const { AwsSnsModule, AwsSnsService } = await Modules.aws.load()
 
 			try {
 				const awsSnsModule = await this.lazyModuleLoader.load(() => AwsSnsModule)

--- a/backend/core/src/modules/beacon/sms/sms.service.ts
+++ b/backend/core/src/modules/beacon/sms/sms.service.ts
@@ -51,7 +51,6 @@ export class BeaconSmsService {
 		let service: any
 
 		if (Modules.aws.isInstalled) {
-			//@ts-ignore
 			const { AwsSnsModule, AwsSnsService } = await Modules.aws.load()
 
 			try {

--- a/backend/core/src/modules/fx/fx.service.ts
+++ b/backend/core/src/modules/fx/fx.service.ts
@@ -87,9 +87,9 @@ export class FxService {
 			return calc(amount, rates[from], rates[to])
 		}
 
-		if (Modules.isInstalled('@juicyllama/data-cache')) {
+		if (Modules.datacache.isInstalled) {
 			//@ts-ignore
-			const { DataCacheModule, DataCacheService, Fx } = await import('@juicyllama/data-cache')
+			const { DataCacheModule, DataCacheService, Fx } = await Modules.datacache.load()
 
 			try {
 				const dataCacheModule = await this.lazyModuleLoader.load(() => DataCacheModule)
@@ -109,9 +109,9 @@ export class FxService {
 			}
 		}
 
-		if (Modules.isInstalled('@juicyllama/app-apilayer')) {
+		if (Modules.apilayer.isInstalled) {
 			//@ts-ignore
-			const { CurrencyDataModule, CurrencyDataService } = await import('@juicyllama/app-apilayer')
+			const { CurrencyDataModule, CurrencyDataService } = await Modules.apilayer.load()
 			const currencyDataModule = await this.lazyModuleLoader.load(() => CurrencyDataModule)
 			const currencyDataService = currencyDataModule.get(CurrencyDataService)
 
@@ -146,9 +146,9 @@ export class FxService {
 		}
 
 		if (convertResult) {
-			if (Modules.isInstalled('@juicyllama/data-cache')) {
+			if (Modules.datacache.isInstalled) {
 				//@ts-ignore
-				const { DataCacheModule, DataCacheService, Fx } = await import('@juicyllama/data-cache')
+				const { DataCacheModule, DataCacheService, Fx } = await Modules.datacache.load()
 
 				try {
 					const dataCacheModule = await this.lazyModuleLoader.load(() => DataCacheModule)

--- a/backend/core/src/modules/fx/fx.service.ts
+++ b/backend/core/src/modules/fx/fx.service.ts
@@ -88,7 +88,6 @@ export class FxService {
 		}
 
 		if (Modules.datacache.isInstalled) {
-			//@ts-ignore
 			const { DataCacheModule, DataCacheService, Fx } = await Modules.datacache.load()
 
 			try {
@@ -110,7 +109,6 @@ export class FxService {
 		}
 
 		if (Modules.apilayer.isInstalled) {
-			//@ts-ignore
 			const { CurrencyDataModule, CurrencyDataService } = await Modules.apilayer.load()
 			const currencyDataModule = await this.lazyModuleLoader.load(() => CurrencyDataModule)
 			const currencyDataService = currencyDataModule.get(CurrencyDataService)
@@ -147,7 +145,6 @@ export class FxService {
 
 		if (convertResult) {
 			if (Modules.datacache.isInstalled) {
-				//@ts-ignore
 				const { DataCacheModule, DataCacheService, Fx } = await Modules.datacache.load()
 
 				try {

--- a/backend/core/src/modules/storage/storage.service.ts
+++ b/backend/core/src/modules/storage/storage.service.ts
@@ -50,9 +50,9 @@ export class StorageService {
 
 		let service: any
 
-		if (Modules.isInstalled('@juicyllama/app-aws')) {
+		if (Modules.aws.isInstalled) {
 			//@ts-ignore
-			const { AwsS3Module, AwsS3Service } = await import('@juicyllama/app-aws')
+			const { AwsS3Module, AwsS3Service } = await Modules.aws.load()
 
 			try {
 				const awsS3Module = await this.lazyModuleLoader.load(() => AwsS3Module)
@@ -83,9 +83,9 @@ export class StorageService {
 
 		let service: any
 
-		if (Modules.isInstalled('@juicyllama/app-aws')) {
+		if (Modules.aws.isInstalled) {
 			//@ts-ignore
-			const { AwsS3Module, AwsS3Service } = await import('@juicyllama/app-aws')
+			const { AwsS3Module, AwsS3Service } = await Modules.aws.load()
 			const awsS3Module = await this.lazyModuleLoader.load(() => AwsS3Module)
 			service = awsS3Module.get(AwsS3Service)
 			return await service.findAll(location, permissions)
@@ -124,9 +124,9 @@ export class StorageService {
 
 		let service: any
 
-		if (Modules.isInstalled('@juicyllama/app-aws')) {
+		if (Modules.aws.isInstalled) {
 			//@ts-ignore
-			const { AwsS3Module, AwsS3Service } = await import('@juicyllama/app-aws')
+			const { AwsS3Module, AwsS3Service } = await Modules.aws.load()
 			const awsS3Module = await this.lazyModuleLoader.load(() => AwsS3Module)
 			service = awsS3Module.get(AwsS3Service)
 			file = await service.findOne(location, permissions, format)
@@ -163,9 +163,9 @@ export class StorageService {
 
 		let service: any
 
-		if (Modules.isInstalled('@juicyllama/app-aws')) {
+		if (Modules.aws.isInstalled) {
 			//@ts-ignore
-			const { AwsS3Module, AwsS3Service } = await import('@juicyllama/app-aws')
+			const { AwsS3Module, AwsS3Service } = await Modules.aws.load()
 			const awsS3Module = await this.lazyModuleLoader.load(() => AwsS3Module)
 			service = awsS3Module.get(AwsS3Service)
 			await service.remove(location, permissions)

--- a/backend/core/src/modules/storage/storage.service.ts
+++ b/backend/core/src/modules/storage/storage.service.ts
@@ -51,7 +51,6 @@ export class StorageService {
 		let service: any
 
 		if (Modules.aws.isInstalled) {
-			//@ts-ignore
 			const { AwsS3Module, AwsS3Service } = await Modules.aws.load()
 
 			try {
@@ -84,7 +83,6 @@ export class StorageService {
 		let service: any
 
 		if (Modules.aws.isInstalled) {
-			//@ts-ignore
 			const { AwsS3Module, AwsS3Service } = await Modules.aws.load()
 			const awsS3Module = await this.lazyModuleLoader.load(() => AwsS3Module)
 			service = awsS3Module.get(AwsS3Service)
@@ -125,7 +123,6 @@ export class StorageService {
 		let service: any
 
 		if (Modules.aws.isInstalled) {
-			//@ts-ignore
 			const { AwsS3Module, AwsS3Service } = await Modules.aws.load()
 			const awsS3Module = await this.lazyModuleLoader.load(() => AwsS3Module)
 			service = awsS3Module.get(AwsS3Service)
@@ -164,7 +161,6 @@ export class StorageService {
 		let service: any
 
 		if (Modules.aws.isInstalled) {
-			//@ts-ignore
 			const { AwsS3Module, AwsS3Service } = await Modules.aws.load()
 			const awsS3Module = await this.lazyModuleLoader.load(() => AwsS3Module)
 			service = awsS3Module.get(AwsS3Service)

--- a/backend/crm/src/contacts/contacts.service.ts
+++ b/backend/crm/src/contacts/contacts.service.ts
@@ -122,11 +122,11 @@ export class ContactsService extends BaseService<T> {
 	async patchMailchimp(contact: T): Promise<void> {
 		const domain = 'crm::contacts::service::patchMailchimp'
 
-		if (Modules.isInstalled('@juicyllama/app-mailchimp') && contact.emails?.length) {
+		if (Modules.mailchimp.isInstalled && contact.emails?.length) {
 			this.logger.verbose(`[${domain}] Mailchimp is installed`)
 
 			//@ts-ignore
-			const { MailchimpModule, MailchimpService } = await import('@juicyllama/app-mailchimp')
+			const { MailchimpModule, MailchimpService } = await Modules.mailchimp.load()
 
 			try {
 				const mailchimpModule = await this.lazyModuleLoader.load(() => MailchimpModule)
@@ -141,11 +141,11 @@ export class ContactsService extends BaseService<T> {
 	async deleteMailchimp(contact: T): Promise<void> {
 		const domain = 'crm::contacts::service::deleteMailchimp'
 
-		if (Modules.isInstalled('@juicyllama/app-mailchimp') && contact.emails?.length) {
+		if (Modules.mailchimp.isInstalled && contact.emails?.length) {
 			this.logger.verbose(`[${domain}] Mailchimp is installed`)
 
 			//@ts-ignore
-			const { MailchimpModule, MailchimpService } = await import('@juicyllama/app-mailchimp')
+			const { MailchimpModule, MailchimpService } = await Modules.aws.load()
 
 			try {
 				const mailchimpModule = await this.lazyModuleLoader.load(() => MailchimpModule)

--- a/backend/crm/src/contacts/contacts.service.ts
+++ b/backend/crm/src/contacts/contacts.service.ts
@@ -125,7 +125,6 @@ export class ContactsService extends BaseService<T> {
 		if (Modules.mailchimp.isInstalled && contact.emails?.length) {
 			this.logger.verbose(`[${domain}] Mailchimp is installed`)
 
-			//@ts-ignore
 			const { MailchimpModule, MailchimpService } = await Modules.mailchimp.load()
 
 			try {
@@ -144,7 +143,6 @@ export class ContactsService extends BaseService<T> {
 		if (Modules.mailchimp.isInstalled && contact.emails?.length) {
 			this.logger.verbose(`[${domain}] Mailchimp is installed`)
 
-			//@ts-ignore
 			const { MailchimpModule, MailchimpService } = await Modules.aws.load()
 
 			try {

--- a/backend/crm/src/contacts/phone/phone.service.ts
+++ b/backend/crm/src/contacts/phone/phone.service.ts
@@ -47,9 +47,9 @@ export class ContactPhoneService extends BaseService<T> {
 			return false
 		}
 
-		if (Modules.isInstalled('@juicyllama/data-cache')) {
+		if (Modules.datacache.isInstalled) {
 			//@ts-ignore
-			const { DataCacheModule, DataCacheService, NumberVerification } = await import('@juicyllama/data-cache')
+			const { DataCacheModule, DataCacheService, NumberVerification } = await Modules.datacache.load()
 
 			try {
 				const dataCacheModule = await this.lazyModuleLoader.load(() => DataCacheModule)
@@ -74,9 +74,9 @@ export class ContactPhoneService extends BaseService<T> {
 			}
 		}
 
-		if (Modules.isInstalled('@juicyllama/app-apilayer')) {
+		if (Modules.apilayer.isInstalled) {
 			//@ts-ignore
-			const { NumberVerificationModule, NumberVerificationService } = await import('@juicyllama/app-apilayer')
+			const { NumberVerificationModule, NumberVerificationService } = await Modules.apilayer.load()
 			const numberVerificationModule = await this.lazyModuleLoader.load(() => NumberVerificationModule)
 			const numberVerificationService = numberVerificationModule.get(NumberVerificationService)
 
@@ -101,9 +101,9 @@ export class ContactPhoneService extends BaseService<T> {
 				})
 			}
 
-			if (Modules.isInstalled('@juicyllama/data-cache')) {
+			if (Modules.datacache.isInstalled) {
 				//@ts-ignore
-				const { DataCacheModule, DataCacheService, NumberVerification } = await import('@juicyllama/data-cache')
+				const { DataCacheModule, DataCacheService, NumberVerification } = await Modules.datacache.load()
 
 				try {
 					const dataCacheModule = await this.lazyModuleLoader.load(() => DataCacheModule)
@@ -117,7 +117,7 @@ export class ContactPhoneService extends BaseService<T> {
 			return result.valid
 		}
 
-		if (!Modules.isInstalled('@juicyllama/app-apilayer')) {
+		if (!Modules.apilayer.isInstalled) {
 			this.logger.warn(
 				`[${domain}] Skipping number verification as no service is installed, consider installing one of: ApiLayer`,
 			)
@@ -132,7 +132,7 @@ export class ContactPhoneService extends BaseService<T> {
 			return false
 		}
 
-		if (!Modules.isInstalled('@juicyllama/app-apilayer')) {
+		if (!Modules.apilayer.isInstalled) {
 			this.logger.warn(
 				`[${domain}] Skipping number verification as no service is installed, consider installing one of: ApiLayer`,
 			)
@@ -140,7 +140,7 @@ export class ContactPhoneService extends BaseService<T> {
 		}
 
 		//@ts-ignore
-		const { NumberVerificationModule, NumberVerificationService } = await import('@juicyllama/app-apilayer')
+		const { NumberVerificationModule, NumberVerificationService } = await Modules.apilayer.load()
 		const numberVerificationModule = await this.lazyModuleLoader.load(() => NumberVerificationModule)
 		const numberVerificationService = numberVerificationModule.get(NumberVerificationService)
 

--- a/backend/crm/src/contacts/phone/phone.service.ts
+++ b/backend/crm/src/contacts/phone/phone.service.ts
@@ -48,7 +48,6 @@ export class ContactPhoneService extends BaseService<T> {
 		}
 
 		if (Modules.datacache.isInstalled) {
-			//@ts-ignore
 			const { DataCacheModule, DataCacheService, NumberVerification } = await Modules.datacache.load()
 
 			try {
@@ -75,7 +74,6 @@ export class ContactPhoneService extends BaseService<T> {
 		}
 
 		if (Modules.apilayer.isInstalled) {
-			//@ts-ignore
 			const { NumberVerificationModule, NumberVerificationService } = await Modules.apilayer.load()
 			const numberVerificationModule = await this.lazyModuleLoader.load(() => NumberVerificationModule)
 			const numberVerificationService = numberVerificationModule.get(NumberVerificationService)
@@ -102,7 +100,6 @@ export class ContactPhoneService extends BaseService<T> {
 			}
 
 			if (Modules.datacache.isInstalled) {
-				//@ts-ignore
 				const { DataCacheModule, DataCacheService, NumberVerification } = await Modules.datacache.load()
 
 				try {
@@ -139,7 +136,6 @@ export class ContactPhoneService extends BaseService<T> {
 			return true
 		}
 
-		//@ts-ignore
 		const { NumberVerificationModule, NumberVerificationService } = await Modules.apilayer.load()
 		const numberVerificationModule = await this.lazyModuleLoader.load(() => NumberVerificationModule)
 		const numberVerificationService = numberVerificationModule.get(NumberVerificationService)

--- a/backend/crm/src/crons/crm.crons.contacts.service.ts
+++ b/backend/crm/src/crons/crm.crons.contacts.service.ts
@@ -20,8 +20,8 @@ export class CrmCronsContactsService {
 		if (![Enviroment.test].includes(this.configService.get('NODE_ENV'))) {
 			let Bugsnag: any
 
-			if (Modules.isInstalled('@bugsnag/js')) {
-				Bugsnag = require('@bugsnag/js')
+			if (Modules.bugsnag.isInstalled) {
+				Bugsnag = Modules.bugsnag.load()
 				Bugsnag.addMetadata('cron', {
 					domain: domain,
 				})

--- a/common/docs/content/common/utils/utils.md
+++ b/common/docs/content/common/utils/utils.md
@@ -644,7 +644,7 @@ import { Modules } from '@juicyllama/utils'
 Check if a module is installed:
 
 ```typescript
-const isInstalled = Modules.isInstalled('react')
+const isInstalled = Modules.slack.isInstalled
 //isInstalled = true
 ```
 

--- a/common/utils/src/utils/Logger.ts
+++ b/common/utils/src/utils/Logger.ts
@@ -10,8 +10,8 @@ export class Logger {
 		if (Env.IsNotTest()) {
 			let Bugsnag: any
 
-			if (Modules.isInstalled('@bugsnag/js')) {
-				Bugsnag = require('@bugsnag/js')
+			if (Modules.bugsnag.isInstalled) {
+				Bugsnag = Modules.bugsnag.load()
 				Bugsnag.addMetadata(key, value)
 			}
 		}
@@ -36,9 +36,10 @@ export class Logger {
 				case 'Unexpected token o in JSON at position 1SyntaxError: Unexpected token o in JSON at position 1':
 					break
 				default:
-					if (Modules.isInstalled('@bugsnag/js')) {
-						const Bugsnag = require('@bugsnag/js')
-						Bugsnag.notify(new Error(message))
+					if (Modules.bugsnag.isInstalled) {
+						Modules.bugsnag.load().then((Bugsnag)=> {
+							Bugsnag.notify(new Error(message))
+						})
 					}
 			}
 		}
@@ -124,9 +125,10 @@ export class Logger {
 			}
 		} catch (e) {
 			this.error(e.message)
-			if (Modules.isInstalled('@bugsnag/js')) {
-				const Bugsnag = require('@bugsnag/js')
-				Bugsnag.notify(new Error(e))
+			if (Modules.bugsnag.isInstalled) {
+				Modules.bugsnag.load().then((Bugsnag) => {
+					Bugsnag.notify(new Error(e))
+				})
 			}
 		}
 

--- a/common/utils/src/utils/Markdown.ts
+++ b/common/utils/src/utils/Markdown.ts
@@ -9,8 +9,8 @@ export class Markdown {
 	 */
 
 	async markdownToHTML(markdown: string): Promise<string> {
-		if (Modules.isInstalled('showdown')) {
-			const showdown = await import('showdown')
+		if (Modules.showdown.isInstalled) {
+			const showdown = await Modules.showdown.load()
 			const converter = new showdown.Converter()
 			return converter.makeHtml(markdown)
 		} else {

--- a/common/utils/src/utils/Modules.ts
+++ b/common/utils/src/utils/Modules.ts
@@ -1,6 +1,20 @@
 import { Logger } from './Logger'
 
+class Module<T = any> {
+	constructor(public readonly name: string) {}
+
+	public get isInstalled() {
+		return Modules.isInstalled(this.name)
+	}
+
+	public async load() {
+		return Modules.load<T>(this.name)
+	}
+}
+
 export class Modules {
+	public static readonly appAws = new Module('@juicyllama/app-aws');
+
 	/**
 	 * Checks if a module is installed
 	 *
@@ -18,7 +32,7 @@ export class Modules {
 		}
 	}
 
-	static load(name: string): unknown {
-		return require.main.require(name);
+	static async load<T = any>(name: string): Promise<T> {
+		return require.main.require(name)
 	}
 }

--- a/common/utils/src/utils/Modules.ts
+++ b/common/utils/src/utils/Modules.ts
@@ -17,4 +17,8 @@ export class Modules {
 			return false
 		}
 	}
+
+	static load(name: string): unknown {
+		return require.main.require(name);
+	}
 }

--- a/common/utils/src/utils/Modules.ts
+++ b/common/utils/src/utils/Modules.ts
@@ -13,11 +13,31 @@ class Module<T = any> {
 }
 
 export class Modules {
-	public static readonly appAws = new Module('@juicyllama/app-aws');
+	//framework app lazyload modules
+	public static readonly apilayer = new Module('@juicyllama/app-apilayer');
+	public static readonly aws = new Module('@juicyllama/app-aws');
+	public static readonly everflow = new Module('@juicyllama/app-everflow');
+	public static readonly mailchimp = new Module('@juicyllama/app-mailchimp');
+	public static readonly mollie = new Module('@juicyllama/app-mollie');
+	public static readonly openai = new Module('@juicyllama/app-openai');
+	public static readonly pexels = new Module('@juicyllama/app-pexels');
+	public static readonly scrapingbee = new Module('@juicyllama/app-scrapingbee');
+	public static readonly shopify = new Module('@juicyllama/app-shopify');
+	public static readonly slack = new Module('@juicyllama/app-slack');
+	public static readonly wise = new Module('@juicyllama/app-wise');
+	public static readonly wordpress = new Module('@juicyllama/app-wordpress');
+	public static readonly xerocc = new Module('@juicyllama/app-xero-cc');
+
+	//framework lazyload modules
+	public static readonly datacache = new Module('@juicyllama/data-cache');
+
+	//non-framework lazyload modules
+	public static readonly bugsnag = new Module('@bugsnag/js');
+	public static readonly pusher = new Module('pusher');
+	public static readonly showdown = new Module('showdown');
 
 	/**
 	 * Checks if a module is installed
-	 *
 	 * Warning: require.resolve is not working in frontend aps like vue, use installed instead
 	 */
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18673,7 +18673,7 @@ packages:
       postcss-nested: 6.0.1(postcss@8.4.31)
       recast: 0.22.0
       scule: 1.1.0
-      style-dictionary-esm: 1.8.4
+      style-dictionary-esm: 1.9.2
       unbuild: 1.2.1
       unplugin: 1.5.1
     transitivePeerDependencies:
@@ -21006,8 +21006,8 @@ packages:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
     dev: false
 
-  /style-dictionary-esm@1.8.4:
-    resolution: {integrity: sha512-R4N/s/6KYU62+Q+wl/fSm9Eh2AbbUQoPJZfEl1EZbDEYZSb9fqprKDwbNLbYqH4XnV9L8GIYkijXXf4z9iv3mw==}
+  /style-dictionary-esm@1.9.2:
+    resolution: {integrity: sha512-MR+ppTqzkJJtXH6UyDJ0h4h4ekBCePA8A8xlYNuL0tLj2K+ngyuxoe0AvCHQ7sJVX8O5WK2z32ANSgIcF4mGxw==}
     hasBin: true
     dependencies:
       chalk: 5.3.0


### PR DESCRIPTION
@andyslack This is a possible solution.
If accepted, it would need to be propagated to all instances of modules dynamic import.

I like it as it encapsulates `Modules.load` together with `Modules.isInstalled`, so in the future, this will give us flexibility if we need to overhaul the module loading approach.

I'm considering making `Modules.load` async, to give even more options for changing the underlying logic, but I'm not sure if we would ever need it and how much trouble it would be to change all affected codes if we do.