### PR TITLE
refactor: feedback and improvements around the ShopifyModule

### DIFF
--- a/apps/shopify/src/config/shopify.config.dto.ts
+++ b/apps/shopify/src/config/shopify.config.dto.ts
@@ -1,6 +1,6 @@
 import { IsString, IsUrl } from 'class-validator'
 
-export class shopifyConfigDto {
+export class ShopifyConfigDto {
 	@IsUrl()
 	SHOPIFY_APP_CLIENT_ID: string
 

--- a/apps/shopify/src/config/shopify.config.joi.ts
+++ b/apps/shopify/src/config/shopify.config.joi.ts
@@ -1,8 +1,8 @@
 import Joi from 'joi'
 
-export const shopifyConfigJoi = {
+export const shopifyConfigJoi = Joi.object({
 	SHOPIFY_APP_CLIENT_ID: Joi.string().required(),
 	SHOPIFY_APP_CLIENT_SECRET: Joi.string().required(),
 	SHOPIFY_EXTRA_SCOPES: Joi.string().optional(),
 	SHOPIFY_OAUTH_REDIRECT_URL: Joi.string().optional(),
-}
+})

--- a/apps/shopify/src/config/shopify.config.ts
+++ b/apps/shopify/src/config/shopify.config.ts
@@ -1,8 +1,8 @@
+import { InstalledApp, Oauth } from '@juicyllama/app-store'
 import { registerAs } from '@nestjs/config'
 import '@shopify/shopify-api/adapters/node'
 import { shopifyApi, LATEST_API_VERSION, Session } from '@shopify/shopify-api'
 import { shopifyConfigDto } from './shopify.config.dto'
-import { InstalledApp, Oauth } from '@juicyllama/app-store'
 
 export default registerAs(
 	'shopify',

--- a/apps/shopify/src/config/shopify.config.ts
+++ b/apps/shopify/src/config/shopify.config.ts
@@ -2,7 +2,7 @@ import { InstalledApp, Oauth } from '@juicyllama/app-store'
 import { registerAs } from '@nestjs/config'
 import '@shopify/shopify-api/adapters/node'
 import { shopifyApi, LATEST_API_VERSION, Session } from '@shopify/shopify-api'
-import { shopifyConfigDto } from './shopify.config.dto'
+import { ShopifyConfigDto } from './shopify.config.dto'
 
 export default registerAs(
 	'shopify',
@@ -28,7 +28,7 @@ export const ShopifyAuthScopes = [
 
 export const ShopifyAuthRedirect = '/app/shopify/auth/redirect'
 
-export function Shopify(config: shopifyConfigDto) {
+export function Shopify(config: ShopifyConfigDto) {
 	return shopifyApi({
 		apiKey: config.SHOPIFY_APP_CLIENT_ID,
 		apiSecretKey: config.SHOPIFY_APP_CLIENT_SECRET,

--- a/apps/shopify/src/index.ts
+++ b/apps/shopify/src/index.ts
@@ -2,6 +2,7 @@
 export { ShopifyModule } from './modules/shopify.module'
 export { ShopifyAuthModule } from './modules/auth/auth.module'
 export { ShopifyOrdersModule } from './modules/orders/orders.module'
+export { ShopifyProviderModule } from './modules/provider/provider.module'
 export { ShopifyWebhooksModule } from './modules/webhooks/webhooks.module'
 
 // Controllers
@@ -40,3 +41,6 @@ export {
 	ShopifyRestListOrders,
 } from './modules/orders/orders.dto'
 export { ShopifyWebhook, ShopifyWebhookCreate, ShopifyRestListWebhooks } from './modules/webhooks/webhooks.dto'
+
+// Constants and decorators
+export { InjectShopify, SHOPIFY_PROVIDER_TOKEN } from './modules/provider/provider.constants'

--- a/apps/shopify/src/modules/auth/auth.controller.ts
+++ b/apps/shopify/src/modules/auth/auth.controller.ts
@@ -1,25 +1,25 @@
-import { Controller, forwardRef, Inject, Get, Query, Req, Res, BadRequestException } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
-import { ApiHideProperty } from '@nestjs/swagger'
-import { Logger } from '@juicyllama/utils'
-import { ShopifyAuthRedirectQuery } from './auth.dto'
-import { ShopifyAuthRedirect, ShopifyAuthScopes } from '../../config/shopify.config'
 import { AppIntegrationStatus, InstalledAppsService, Oauth, OauthService } from '@juicyllama/app-store'
 import { AccountId, UserAuth } from '@juicyllama/core'
-import { v4 as uuidv4 } from 'uuid'
 import { StoresService } from '@juicyllama/ecommerce'
-import { InjectShopify } from '../provider/provider.constants'
+import { Logger } from '@juicyllama/utils'
+import { Controller, Get, Query, Req, Res, BadRequestException } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { ApiHideProperty } from '@nestjs/swagger'
 import { Shopify } from '@shopify/shopify-api'
+import { v4 as uuidv4 } from 'uuid'
+import { ShopifyAuthRedirect, ShopifyAuthScopes } from '../../config/shopify.config'
+import { InjectShopify } from '../provider/provider.constants'
+import { ShopifyAuthRedirectQuery } from './auth.dto'
 
 @Controller('app/shopify/auth')
 export class ShopifyAuthController {
 	constructor(
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
+		private readonly logger: Logger,
 		private readonly configService: ConfigService,
 		@InjectShopify() private readonly shopify: Shopify,
-		@Inject(forwardRef(() => OauthService)) private readonly oauthService: OauthService,
-		@Inject(forwardRef(() => InstalledAppsService)) private readonly installedAppsService: InstalledAppsService,
-		@Inject(forwardRef(() => StoresService)) private readonly storesService: StoresService,
+		private readonly oauthService: OauthService,
+		private readonly installedAppsService: InstalledAppsService,
+		private readonly storesService: StoresService,
 	) {}
 
 	@UserAuth()
@@ -145,7 +145,7 @@ export class ShopifyAuthController {
 		this.logger.log(`[${domain}] Callback`, {
 			callback: callback,
 			state: req.cookies.app_shopify_state,
-			reidrect_url: req.cookies.app_shopify_redirect_url,
+			redirect_url: req.cookies.app_shopify_redirect_url,
 		})
 
 		const oath = await this.oauthService.findOne({ where: { state: req.cookies.app_shopify_state } })

--- a/apps/shopify/src/modules/auth/auth.module.ts
+++ b/apps/shopify/src/modules/auth/auth.module.ts
@@ -1,29 +1,20 @@
-import { Module, forwardRef } from '@nestjs/common'
-import { ConfigModule } from '@nestjs/config'
-import { Env, Logger } from '@juicyllama/utils'
-import Joi from 'joi'
-import shopifyConfig from '../../config/shopify.config'
-import { shopifyConfigJoi } from '../../config/shopify.config.joi'
-import { ShopifyAuthController } from './auth.controller'
 import { AppsModule, InstalledAppsModule, OAuthModule } from '@juicyllama/app-store'
 import { AuthModule, jwtConfig } from '@juicyllama/core'
-import { JwtModule } from '@nestjs/jwt'
 import { StoresModule } from '@juicyllama/ecommerce'
+import { Logger } from '@juicyllama/utils'
+import { Module } from '@nestjs/common'
+import { JwtModule } from '@nestjs/jwt'
 import { ShopifyProviderModule } from '../provider/provider.module'
+import { ShopifyAuthController } from './auth.controller'
 
 @Module({
 	imports: [
-		ConfigModule.forRoot({
-			isGlobal: true,
-			load: [shopifyConfig],
-			validationSchema: Env.IsNotTest() ? Joi.object(shopifyConfigJoi) : null,
-		}),
 		JwtModule.register(jwtConfig()),
-		forwardRef(() => AuthModule),
-		forwardRef(() => AppsModule),
-		forwardRef(() => OAuthModule),
-		forwardRef(() => InstalledAppsModule),
-		forwardRef(() => StoresModule),
+		AuthModule,
+		AppsModule,
+		OAuthModule,
+		InstalledAppsModule,
+		StoresModule,
 		ShopifyProviderModule,
 	],
 	controllers: [ShopifyAuthController],

--- a/apps/shopify/src/modules/auth/auth.module.ts
+++ b/apps/shopify/src/modules/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { AppsModule, InstalledAppsModule, OAuthModule } from '@juicyllama/app-st
 import { AuthModule, jwtConfig } from '@juicyllama/core'
 import { JwtModule } from '@nestjs/jwt'
 import { StoresModule } from '@juicyllama/ecommerce'
+import { ShopifyProviderModule } from '../provider/provider.module'
 
 @Module({
 	imports: [
@@ -23,6 +24,7 @@ import { StoresModule } from '@juicyllama/ecommerce'
 		forwardRef(() => OAuthModule),
 		forwardRef(() => InstalledAppsModule),
 		forwardRef(() => StoresModule),
+		ShopifyProviderModule,
 	],
 	controllers: [ShopifyAuthController],
 	providers: [Logger],

--- a/apps/shopify/src/modules/customers/customers.controller.ts
+++ b/apps/shopify/src/modules/customers/customers.controller.ts
@@ -1,16 +1,16 @@
-import { Controller, forwardRef, Inject, Query, Body, Post } from '@nestjs/common'
-import { ApiHideProperty } from '@nestjs/swagger'
-import { Logger } from '@juicyllama/utils'
 import { InstalledAppsService } from '@juicyllama/app-store'
 import { Transaction } from '@juicyllama/ecommerce'
+import { Logger } from '@juicyllama/utils'
+import { Controller, Query, Body, Post } from '@nestjs/common'
+import { ApiHideProperty } from '@nestjs/swagger'
 import { ShopifyCustomersService } from './customers.service'
 
 @Controller('app/shopify/customers')
 export class ShopifyCustomersController {
 	constructor(
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
-		@Inject(forwardRef(() => ShopifyCustomersService)) private readonly shopifyShopService: ShopifyCustomersService,
-		@Inject(forwardRef(() => InstalledAppsService)) private readonly installedAppsService: InstalledAppsService,
+		private readonly logger: Logger,
+		private readonly shopifyShopService: ShopifyCustomersService,
+		private readonly installedAppsService: InstalledAppsService,
 	) {}
 
 	/**

--- a/apps/shopify/src/modules/customers/customers.module.ts
+++ b/apps/shopify/src/modules/customers/customers.module.ts
@@ -2,12 +2,11 @@ import { InstalledAppsModule } from '@juicyllama/app-store'
 import { StoresModule } from '@juicyllama/ecommerce'
 import { Logger } from '@juicyllama/utils'
 import { Module } from '@nestjs/common'
-import { ScheduleModule } from '@nestjs/schedule'
 import { ShopifyCustomersController } from './customers.controller'
 import { ShopifyCustomersService } from './customers.service'
 
 @Module({
-	imports: [ScheduleModule.forRoot(), InstalledAppsModule, StoresModule],
+	imports: [InstalledAppsModule, StoresModule],
 	controllers: [ShopifyCustomersController],
 	providers: [ShopifyCustomersService, Logger],
 	exports: [ShopifyCustomersService],

--- a/apps/shopify/src/modules/customers/customers.module.ts
+++ b/apps/shopify/src/modules/customers/customers.module.ts
@@ -1,26 +1,13 @@
-import { Module, forwardRef } from '@nestjs/common'
-import { ConfigModule } from '@nestjs/config'
-import { Env, Logger } from '@juicyllama/utils'
-import Joi from 'joi'
-import shopifyConfig from '../../config/shopify.config'
-import { shopifyConfigJoi } from '../../config/shopify.config.joi'
 import { InstalledAppsModule } from '@juicyllama/app-store'
-import { ShopifyCustomersService } from './customers.service'
-import { ShopifyCustomersController } from './customers.controller'
-import { ScheduleModule } from '@nestjs/schedule'
 import { StoresModule } from '@juicyllama/ecommerce'
+import { Logger } from '@juicyllama/utils'
+import { Module } from '@nestjs/common'
+import { ScheduleModule } from '@nestjs/schedule'
+import { ShopifyCustomersController } from './customers.controller'
+import { ShopifyCustomersService } from './customers.service'
 
 @Module({
-	imports: [
-		ConfigModule.forRoot({
-			isGlobal: true,
-			load: [shopifyConfig],
-			validationSchema: Env.IsNotTest() ? Joi.object(shopifyConfigJoi) : null,
-		}),
-		ScheduleModule.forRoot(),
-		forwardRef(() => InstalledAppsModule),
-		forwardRef(() => StoresModule),
-	],
+	imports: [ScheduleModule.forRoot(), InstalledAppsModule, StoresModule],
 	controllers: [ShopifyCustomersController],
 	providers: [ShopifyCustomersService, Logger],
 	exports: [ShopifyCustomersService],

--- a/apps/shopify/src/modules/customers/customers.service.ts
+++ b/apps/shopify/src/modules/customers/customers.service.ts
@@ -1,12 +1,12 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common'
-import { Logger } from '@juicyllama/utils'
 import { Contact, ContactsService } from '@juicyllama/crm'
+import { Logger } from '@juicyllama/utils'
+import { Injectable } from '@nestjs/common'
 
 @Injectable()
 export class ShopifyCustomersService {
 	constructor(
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
-		@Inject(forwardRef(() => ContactsService)) private readonly constactsService: ContactsService,
+		private readonly logger: Logger,
+		private readonly constactsService: ContactsService,
 	) {}
 
 	/**

--- a/apps/shopify/src/modules/orders/orders.controller.ts
+++ b/apps/shopify/src/modules/orders/orders.controller.ts
@@ -5,7 +5,7 @@ import { Logger } from '@juicyllama/utils'
 import { Controller, Get, Query, BadRequestException, Body, Post } from '@nestjs/common'
 import { ApiHideProperty } from '@nestjs/swagger'
 import { ApiVersion } from '@shopify/shopify-api'
-import { ShopifyOrder } from './orders.dto'
+import { ShopifyOrder, ShopifyQueryListOrders } from './orders.dto'
 import { ShopifyOrdersService } from './orders.service'
 
 @Controller('app/shopify/orders')
@@ -25,7 +25,7 @@ export class ShopifyOrdersController {
 	@Get('sync')
 	async sync(
 		@AccountId() account_id: number,
-		@Query() { installed_app_id, ...query }: { installed_app_id: number; [key: string]: any },
+		@Query() { installed_app_id, ...query }: ShopifyQueryListOrders,
 	): Promise<Transaction[]> {
 		const domain = 'app::shopify::orders::controller::sync'
 
@@ -62,7 +62,7 @@ export class ShopifyOrdersController {
 	@Get('list')
 	async list(
 		@AccountId() account_id: number,
-		@Query() { installed_app_id, ...query }: { installed_app_id: number; [key: string]: any },
+		@Query() { installed_app_id, ...query }: ShopifyQueryListOrders,
 	): Promise<ShopifyOrder[]> {
 		const domain = 'app::shopify::orders::controller::list'
 

--- a/apps/shopify/src/modules/orders/orders.controller.ts
+++ b/apps/shopify/src/modules/orders/orders.controller.ts
@@ -1,19 +1,19 @@
-import { Controller, forwardRef, Inject, Get, Query, BadRequestException, Body, Post } from '@nestjs/common'
-import { ApiHideProperty } from '@nestjs/swagger'
-import { Logger } from '@juicyllama/utils'
 import { InstalledAppsService } from '@juicyllama/app-store'
 import { AccountId, UserAuth } from '@juicyllama/core'
-import { ShopifyOrdersService } from './orders.service'
-import { ApiVersion } from '@shopify/shopify-api'
 import { Transaction } from '@juicyllama/ecommerce'
+import { Logger } from '@juicyllama/utils'
+import { Controller, Get, Query, BadRequestException, Body, Post } from '@nestjs/common'
+import { ApiHideProperty } from '@nestjs/swagger'
+import { ApiVersion } from '@shopify/shopify-api'
 import { ShopifyOrder } from './orders.dto'
+import { ShopifyOrdersService } from './orders.service'
 
 @Controller('app/shopify/orders')
 export class ShopifyOrdersController {
 	constructor(
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
-		@Inject(forwardRef(() => ShopifyOrdersService)) private readonly shopifyOrdersService: ShopifyOrdersService,
-		@Inject(forwardRef(() => InstalledAppsService)) private readonly installedAppsService: InstalledAppsService,
+		private readonly logger: Logger,
+		private readonly shopifyOrdersService: ShopifyOrdersService,
+		private readonly installedAppsService: InstalledAppsService,
 	) {}
 
 	/**
@@ -24,9 +24,8 @@ export class ShopifyOrdersController {
 	@ApiHideProperty()
 	@Get('sync')
 	async sync(
-		@Query('installed_app_id') installed_app_id: number,
 		@AccountId() account_id: number,
-		@Query() query: any,
+		@Query() { installed_app_id, ...query }: { installed_app_id: number; [key: string]: any },
 	): Promise<Transaction[]> {
 		const domain = 'app::shopify::orders::controller::sync'
 
@@ -47,8 +46,6 @@ export class ShopifyOrdersController {
 			throw new BadRequestException(`Authentication Error: Installed App not found`)
 		}
 
-		delete query.installed_app_id
-
 		return await this.shopifyOrdersService.syncOrders(installed_app, {
 			api_version: ApiVersion.July23,
 			status: 'any',
@@ -64,9 +61,8 @@ export class ShopifyOrdersController {
 	@ApiHideProperty()
 	@Get('list')
 	async list(
-		@Query('installed_app_id') installed_app_id: number,
 		@AccountId() account_id: number,
-		@Query() query: any,
+		@Query() { installed_app_id, ...query }: { installed_app_id: number; [key: string]: any },
 	): Promise<ShopifyOrder[]> {
 		const domain = 'app::shopify::orders::controller::list'
 
@@ -86,8 +82,6 @@ export class ShopifyOrdersController {
 			})
 			throw new BadRequestException(`Authentication Error: Installed App not found`)
 		}
-
-		delete query.installed_app_id
 
 		return await this.shopifyOrdersService.listOrders(installed_app, {
 			api_version: ApiVersion.July23,

--- a/apps/shopify/src/modules/orders/orders.cron.controller.ts
+++ b/apps/shopify/src/modules/orders/orders.cron.controller.ts
@@ -1,16 +1,13 @@
-import { Controller, forwardRef, Inject, Post, UseGuards } from '@nestjs/common'
-import { ApiExcludeController } from '@nestjs/swagger'
 import { CronGuard } from '@juicyllama/core'
+import { Controller, Post, UseGuards } from '@nestjs/common'
+import { ApiExcludeController } from '@nestjs/swagger'
 import { ShopifyOrdersCronService } from './orders.cron.service'
 
 @UseGuards(CronGuard)
 @ApiExcludeController()
 @Controller('app/shopify/crons/orders')
 export class ShopifyOrdersCronController {
-	constructor(
-		@Inject(forwardRef(() => ShopifyOrdersCronService))
-		private readonly shopifyOrdersCronService: ShopifyOrdersCronService,
-	) {}
+	constructor(private readonly shopifyOrdersCronService: ShopifyOrdersCronService) {}
 
 	@Post('sync')
 	async syncOrders(): Promise<any> {

--- a/apps/shopify/src/modules/orders/orders.cron.service.spec.ts
+++ b/apps/shopify/src/modules/orders/orders.cron.service.spec.ts
@@ -1,0 +1,180 @@
+import { AppScope, InstalledApp, InstalledAppsService } from '@juicyllama/app-store'
+import { Store, StoresService, TransactionFulfillmentStatus, TransactionPaymentStatus } from '@juicyllama/ecommerce'
+import { Env, Logger } from '@juicyllama/utils'
+import { Test } from '@nestjs/testing'
+import { ShopifyOrdersCronService } from './orders.cron.service'
+import { ShopifyOrdersService } from './orders.service'
+
+describe('OrdersCronService', () => {
+	let service: ShopifyOrdersCronService
+	let logger: jest.Mocked<Logger>
+	let installedAppsService: jest.Mocked<InstalledAppsService>
+	let shopifyOrdersService: jest.Mocked<ShopifyOrdersService>
+	let storesService: jest.Mocked<StoresService>
+
+	beforeAll(async () => {
+		if (Env.IsNotTest()) {
+			throw new Error('Test suite should not be ran outside of the test environment')
+		}
+
+		const modRef = await Test.createTestingModule({
+			providers: [
+				ShopifyOrdersCronService,
+				{
+					provide: Logger,
+					useValue: {
+						log: jest.fn(),
+						warn: jest.fn(),
+						error: jest.fn(),
+					},
+				},
+				{
+					provide: InstalledAppsService,
+					useValue: {
+						findAll: jest.fn(),
+						update: jest.fn(),
+					},
+				},
+				{
+					provide: ShopifyOrdersService,
+					useValue: {
+						syncOrders: jest.fn(),
+					},
+				},
+				{
+					provide: StoresService,
+					useValue: {
+						findOne: jest.fn(),
+					},
+				},
+			],
+		}).compile()
+
+		service = modRef.get(ShopifyOrdersCronService)
+		logger = modRef.get(Logger)
+		installedAppsService = modRef.get(InstalledAppsService)
+		shopifyOrdersService = modRef.get(ShopifyOrdersService)
+		storesService = modRef.get(StoresService)
+	})
+
+	afterEach(() => {
+		jest.resetAllMocks()
+	})
+
+	it('should be able to create the service', () => {
+		expect(service).toBeDefined()
+	})
+
+	describe('syncOrders', () => {
+		const domain = 'app::shopify::orders::getOrders'
+		const installedApp = {
+			active: true,
+			installed_app_id: 1,
+			app_id: 1,
+			name: 'Test App',
+			scope: AppScope.ACCOUNT,
+			settings: {
+				SHOPIFY_SHOP_NAME: 'test',
+			},
+		}
+		const store: Store = {
+			account_id: 1,
+			store_id: 1,
+		}
+		it('should find nothing to sync', async () => {
+			installedAppsService.findAll.mockResolvedValueOnce([])
+			expect(await service.syncOrders()).toEqual({
+				shopify: {
+					installed_apps: 0,
+					orders: 0,
+					success: 0,
+					failed: 0,
+					failures: [],
+				},
+			})
+		})
+		it('should have only one update', async () => {
+			installedAppsService.findAll.mockResolvedValueOnce([installedApp])
+			storesService.findOne.mockResolvedValueOnce(store)
+			installedAppsService.update.mockResolvedValueOnce(null as unknown as InstalledApp)
+			shopifyOrdersService.syncOrders.mockResolvedValueOnce([
+				{
+					account_id: 1,
+					currency: 'USD',
+					fulfillment_status: TransactionFulfillmentStatus.DELIVERED,
+					installed_app_id: 1,
+					order_id: '1',
+					payment_status: TransactionPaymentStatus.AURHORIZED,
+					store_id: 1,
+					subtotal_price: 0,
+					total_price: 0,
+					total_tax: 0,
+					transaction_id: 1,
+				},
+			])
+			expect(await service.syncOrders()).toEqual({
+				shopify: {
+					installed_apps: 1,
+					orders: 1,
+					success: 1,
+					failed: 0,
+					failures: [],
+				},
+			})
+		})
+		it('should report a missing store', async () => {
+			installedAppsService.findAll.mockResolvedValueOnce([installedApp])
+			storesService.findOne.mockResolvedValueOnce(null as unknown as Store)
+			expect(await service.syncOrders()).toEqual({
+				shopify: {
+					installed_apps: 1,
+					orders: 0,
+					success: 0,
+					failed: 1,
+					failures: [new Error('Store not found for installed app 1')],
+				},
+			})
+			expect(logger.error).toHaveBeenCalledWith(`[${domain}] Store not found`, {
+				installed_app_id: 1,
+			})
+		})
+		it('should fail during updating the installed app', async () => {
+			installedAppsService.update.mockRejectedValueOnce(new Error('Rejection'))
+			installedAppsService.findAll.mockResolvedValueOnce([installedApp])
+			storesService.findOne.mockResolvedValueOnce(store)
+			expect(await service.syncOrders()).toEqual({
+				shopify: {
+					installed_apps: 1,
+					orders: 0,
+					success: 0,
+					failed: 1,
+					failures: [new Error('Rejection')],
+				},
+			})
+			expect(logger.warn).toHaveBeenCalledWith(`[${domain}] Error updating installed app`, {
+				installed_app_id: 1,
+				error: new Error('Rejection'),
+			})
+		})
+		it('should fail while syncing orders', async () => {
+			installedAppsService.findAll.mockResolvedValueOnce([installedApp])
+			storesService.findOne.mockResolvedValueOnce(store)
+			installedAppsService.update.mockResolvedValueOnce(null as unknown as InstalledApp)
+			shopifyOrdersService.syncOrders.mockRejectedValueOnce(new Error('Rejected'))
+			expect(await service.syncOrders()).toEqual({
+				shopify: {
+					installed_apps: 1,
+					orders: 0,
+					success: 0,
+					failed: 1,
+					failures: [new Error('Rejected')],
+				},
+			})
+			expect(logger.warn).toHaveBeenCalledWith(`[${domain}] Error syncing orders for store: test`, {
+				installed_app_id: 1,
+				store,
+				error: new Error('Rejected'),
+			})
+		})
+	})
+})

--- a/apps/shopify/src/modules/orders/orders.cron.service.spec.ts
+++ b/apps/shopify/src/modules/orders/orders.cron.service.spec.ts
@@ -122,6 +122,23 @@ describe('OrdersCronService', () => {
 				},
 			})
 		})
+		it('should log a warn based on an error from storeService', async () => {
+			installedAppsService.findAll.mockResolvedValueOnce([installedApp])
+			storesService.findOne.mockRejectedValueOnce(new Error('StoreService rejection'))
+			expect(await service.syncOrders()).toEqual({
+				shopify: {
+					installed_apps: 1,
+					orders: 0,
+					success: 0,
+					failed: 1,
+					failures: [new Error('StoreService rejection')],
+				},
+			})
+			expect(logger.warn).toHaveBeenCalledWith(`[${domain}] Error looking up store`, {
+				installed_app_id: 1,
+				error: new Error('StoreService rejection'),
+			})
+		})
 		it('should report a missing store', async () => {
 			installedAppsService.findAll.mockResolvedValueOnce([installedApp])
 			storesService.findOne.mockResolvedValueOnce(null as unknown as Store)

--- a/apps/shopify/src/modules/orders/orders.cron.service.ts
+++ b/apps/shopify/src/modules/orders/orders.cron.service.ts
@@ -135,15 +135,17 @@ export class ShopifyOrdersCronService {
 			shopifyPromises.push(shopifyPromise)
 		}
 
-		await Promise.all(shopifyPromises)
+		const promiseResults = await Promise.allSettled(shopifyPromises)
 
 		return {
 			shopify: {
 				installed_apps: installed_apps.length,
 				orders: order_count,
-				success: shopifyPromises.filter(o => o.status === 'fulfilled').length,
-				failed: shopifyPromises.filter(o => o.status === 'rejected').length,
-				failures: shopifyPromises.filter(o => o.status === 'rejected'),
+				success: promiseResults.filter(o => o.status === 'fulfilled').length,
+				failed: promiseResults.filter(o => o.status === 'rejected').length,
+				failures: promiseResults
+					.filter(o => o.status === 'rejected')
+					.map((rej: PromiseRejectedResult) => rej.reason),
 			},
 		}
 	}

--- a/apps/shopify/src/modules/orders/orders.cron.service.ts
+++ b/apps/shopify/src/modules/orders/orders.cron.service.ts
@@ -1,21 +1,21 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common'
-import { Logger } from '@juicyllama/utils'
-import { LessThan, IsNull } from 'typeorm'
 import { AppStoreIntegrationName, InstalledAppsService, AppIntegrationStatus } from '@juicyllama/app-store'
 import { CronRunner } from '@juicyllama/core'
-import { Cron, CronExpression } from '@nestjs/schedule'
 import { StoresService } from '@juicyllama/ecommerce'
-import { ShopifyOrdersService } from './orders.service'
+import { Logger } from '@juicyllama/utils'
+import { Injectable } from '@nestjs/common'
+import { Cron, CronExpression } from '@nestjs/schedule'
 import { ApiVersion } from '@shopify/shopify-api'
 import _ from 'lodash'
+import { LessThan, IsNull } from 'typeorm'
+import { ShopifyOrdersService } from './orders.service'
 
 @Injectable()
 export class ShopifyOrdersCronService {
 	constructor(
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
-		@Inject(forwardRef(() => InstalledAppsService)) private readonly installedAppsService: InstalledAppsService,
-		@Inject(forwardRef(() => ShopifyOrdersService)) private readonly shopifyOrdersService: ShopifyOrdersService,
-		@Inject(forwardRef(() => StoresService)) private readonly storesService: StoresService,
+		private readonly logger: Logger,
+		private readonly installedAppsService: InstalledAppsService,
+		private readonly shopifyOrdersService: ShopifyOrdersService,
+		private readonly storesService: StoresService,
 	) {}
 
 	@Cron(CronExpression.EVERY_10_MINUTES, { disabled: !process.env.CRON_APP_SHOPIFY_SYNC_ORDERS })

--- a/apps/shopify/src/modules/orders/orders.dto.ts
+++ b/apps/shopify/src/modules/orders/orders.dto.ts
@@ -1,3 +1,4 @@
+import { OmitType } from '@nestjs/mapped-types'
 import { IsString, IsNumber, IsOptional, IsDateString, IsBoolean, IsEnum, IsArray, IsObject } from 'class-validator'
 import { ShopifyAddress, ShopifyMoney, ShopifyRestList } from '../shopify.common.dto'
 import { ShopifyCustomer } from '../customers/customers.dto'
@@ -246,4 +247,9 @@ export class ShopifyRestListOrders extends ShopifyRestList {
 	@IsString()
 	@IsOptional()
 	status?: string
+}
+
+export class ShopifyQueryListOrders extends OmitType(ShopifyRestListOrders, ['status', 'api_version'] as const) {
+	@IsNumber()
+	installed_app_id: number
 }

--- a/apps/shopify/src/modules/orders/orders.mapper.service.spec.ts
+++ b/apps/shopify/src/modules/orders/orders.mapper.service.spec.ts
@@ -1,0 +1,403 @@
+import {
+	Contact,
+	ContactAddressService,
+	ContactEmailService,
+	ContactPhoneService,
+	ContactsService,
+} from '@juicyllama/crm'
+import {
+	Store,
+	Transaction,
+	TransactionDiscountType,
+	TransactionDiscountsService,
+	TransactionFulfillmentStatus,
+	TransactionPaymentStatus,
+	TransactionsService,
+} from '@juicyllama/ecommerce'
+import { Env } from '@juicyllama/utils'
+import { Test } from '@nestjs/testing'
+import { ShopifyOrdersMapperService } from './orders.mapper.service'
+import { ShopifyOrder } from './orders.dto'
+import { ShopifyOrderDicountCodeType, ShopifyOrderFinancialStatus, ShopifyOrderFulfillmentStatus } from './orders.enums'
+import { AppScope, InstalledApp } from '@juicyllama/app-store'
+
+describe('OrdersMapperService', () => {
+	let service: ShopifyOrdersMapperService
+	let contactsService: jest.Mocked<ContactsService>
+	let contactEmailsService: jest.Mocked<ContactEmailService>
+	let contactAddressService: jest.Mocked<ContactAddressService>
+	let contactPhoneService: jest.Mocked<ContactPhoneService>
+	let transactionService: jest.Mocked<TransactionsService>
+	let transactionsDiscountService: jest.Mocked<TransactionDiscountsService>
+	const now = new Date()
+	const order: ShopifyOrder = {
+		admin_graphql_api_id: '1',
+		app_id: 1,
+		buyer_accepts_marketing: true,
+		checkout_id: 1,
+		confirmed: true,
+		created_at: now,
+		currency: 'USD',
+		id: 1,
+		name: 'test Order',
+		number: 5,
+		subtotal_price: 49.99,
+		taxes_included: false,
+		test: true,
+		total_outstanding: 54.99,
+		total_tax: 5.0,
+		total_price: 54.99,
+		updated_at: now,
+		order_number: 1,
+	}
+
+	beforeAll(async () => {
+		if (Env.IsNotTest()) {
+			throw new Error('Test suite should not be ran in a non-test environment')
+		}
+
+		const modRef = await Test.createTestingModule({
+			providers: [
+				ShopifyOrdersMapperService,
+				{
+					provide: ContactsService,
+					useValue: {
+						findByEmail: jest.fn(),
+						create: jest.fn(),
+					},
+				},
+				{
+					provide: ContactEmailService,
+					useValue: {
+						create: jest.fn(),
+					},
+				},
+				{
+					provide: ContactPhoneService,
+					useValue: {
+						create: jest.fn(),
+					},
+				},
+				{
+					provide: ContactAddressService,
+					useValue: {
+						create: jest.fn(),
+					},
+				},
+				{
+					provide: TransactionsService,
+					useValue: {
+						create: jest.fn(),
+						update: jest.fn(),
+					},
+				},
+				{
+					provide: TransactionDiscountsService,
+					useValue: {
+						create: jest.fn(),
+					},
+				},
+			],
+		}).compile()
+
+		service = modRef.get(ShopifyOrdersMapperService)
+		contactsService = modRef.get(ContactsService)
+		contactAddressService = modRef.get(ContactAddressService)
+		contactEmailsService = modRef.get(ContactEmailService)
+		contactPhoneService = modRef.get(ContactPhoneService)
+		transactionService = modRef.get(TransactionsService)
+		transactionsDiscountService = modRef.get(TransactionDiscountsService)
+	})
+
+	afterEach(() => {
+		jest.resetAllMocks()
+	})
+
+	it('should create the service without error', () => {
+		expect(service).toBeDefined()
+	})
+
+	describe('createEcommerceTransaction', () => {
+		const installedApp: InstalledApp = {
+			installed_app_id: 1234,
+			active: true,
+			app_id: 123,
+			name: 'test app',
+			scope: AppScope.ACCOUNT,
+			settings: {
+				SHOPIFY_SHOP_NAME: 'test',
+			},
+		}
+
+		const store: Store = {
+			account_id: 1,
+			store_id: 1,
+		}
+
+		const transaction: Transaction = {
+			account_id: 1,
+			currency: 'USD',
+			fulfillment_status: TransactionFulfillmentStatus.SHIPPED,
+			installed_app_id: installedApp.installed_app_id,
+			order_id: order.id.toString(),
+			payment_status: TransactionPaymentStatus.AURHORIZED,
+			store_id: 1,
+			subtotal_price: 49.99,
+			total_price: 54.99,
+			total_tax: 5,
+			transaction_id: 1,
+		}
+
+		it('should generate an email for the order', async () => {
+			const contact = {
+				account_id: 1,
+				contact_id: 1,
+				name: 'test Contact',
+				tags_array: [],
+			}
+			contactsService.findByEmail.mockResolvedValueOnce(null as unknown as Contact)
+			contactsService.create.mockResolvedValueOnce(contact)
+			transactionService.create.mockResolvedValueOnce(transaction)
+			expect(
+				await service.createEcommerceTransaction({ ...order, discount_codes: [] }, store, installedApp),
+			).toEqual({
+				...transaction,
+				contact,
+				shipping_address: undefined,
+				billing_address: undefined,
+				discounts: [],
+			})
+			expect(contactEmailsService.create).toHaveBeenCalledWith({
+				contact_id: 1,
+				email: '1@test.myshopify.com',
+			})
+			expect(transactionService.create).toHaveBeenCalledTimes(1)
+			expect(contactPhoneService.create).not.toHaveBeenCalled()
+			expect(contactAddressService.create).not.toHaveBeenCalled()
+		})
+
+		it('should handle the order having a billing address and shipping address with phone number', async () => {
+			const contact = {
+				name: 'Found Test Contact',
+				account_id: 1,
+				contact_id: 1,
+				tags_array: [],
+			}
+			contactsService.findByEmail.mockResolvedValueOnce(contact)
+			contactAddressService.create
+				.mockResolvedValueOnce({
+					address_id: 1,
+					contact_id: 1,
+				})
+				.mockResolvedValueOnce({
+					address_id: 2,
+					contact_id: 1,
+				})
+			transactionService.create.mockResolvedValueOnce(transaction)
+			expect(
+				await service.createEcommerceTransaction(
+					{
+						...order,
+						discount_codes: [],
+						billing_address: {
+							phone: '1234567890',
+							address1: 'business address 1',
+						},
+						shipping_address: {
+							phone: '9876543210',
+							address1: 'shipping address 1',
+						},
+					},
+					store,
+					installedApp,
+				),
+			).toEqual({
+				...transaction,
+				shipping_address: {
+					address_id: 1,
+					contact_id: 1,
+				},
+				billing_address: {
+					address_id: 2,
+					contact_id: 1,
+				},
+				contact,
+				discounts: [],
+			})
+			expect(contactsService.create).not.toHaveBeenCalled()
+			expect(contactPhoneService.create).toHaveBeenCalledTimes(2)
+			expect(contactAddressService.create).toHaveBeenCalledTimes(2)
+		})
+	})
+
+	describe('updateEcommerceTransaction', () => {
+		const transaction: Transaction = {
+			account_id: 1,
+			currency: 'USD',
+			fulfillment_status: TransactionFulfillmentStatus.SHIPPED,
+			installed_app_id: 1,
+			order_id: '1',
+			payment_status: TransactionPaymentStatus.AURHORIZED,
+			store_id: 1,
+			subtotal_price: 49.99,
+			total_price: 54.99,
+			total_tax: 5,
+			transaction_id: 1,
+			total_outstanding: 54.99,
+		}
+		it('should handle when there are no changes to the transaction', async () => {
+			expect(
+				await service.updateEcommerceTransaction(transaction, {
+					...order,
+					fulfillment_status: ShopifyOrderFulfillmentStatus.fulfilled,
+					financial_status: ShopifyOrderFinancialStatus.authorized,
+				}),
+			).toEqual(transaction)
+			expect(transactionService.update).toHaveBeenCalledTimes(0)
+		})
+
+		it('should call the update method when there are changes', async () => {
+			const changes = {
+				subtotal_price: 59.99,
+				total_price: 69.99,
+				total_tax: 10,
+				total_outstanding: 10,
+				cancelled_at: new Date(),
+				cancel_reason: 'testing',
+			}
+			expect(
+				await service.updateEcommerceTransaction(transaction, {
+					...order,
+					fulfillment_status: ShopifyOrderFulfillmentStatus.partial,
+					financial_status: ShopifyOrderFinancialStatus.partially_paid,
+					...changes,
+				}),
+				// I'm not mocking the return of the `update` method, so jest sets it to `undefined`
+			).toEqual(undefined)
+			expect(transactionService.update).toHaveBeenCalledWith({
+				transaction_id: 1,
+				...changes,
+				fulfillment_status: TransactionFulfillmentStatus.PARTIALLY_SHIPPED,
+				payment_status: TransactionPaymentStatus.PARTPAID,
+			})
+		})
+	})
+
+	describe('shopifyOrderFinancialStatusToEcommerceTransactionStatus', () => {
+		it.each`
+			status                                            | expected
+			${ShopifyOrderFinancialStatus.pending}            | ${TransactionPaymentStatus.PENDING}
+			${ShopifyOrderFinancialStatus.authorized}         | ${TransactionPaymentStatus.AURHORIZED}
+			${ShopifyOrderFinancialStatus.paid}               | ${TransactionPaymentStatus.PAID}
+			${ShopifyOrderFinancialStatus.partially_paid}     | ${TransactionPaymentStatus.PARTPAID}
+			${ShopifyOrderFinancialStatus.partially_refunded} | ${TransactionPaymentStatus.PATRIALREFUND}
+			${ShopifyOrderFinancialStatus.refunded}           | ${TransactionPaymentStatus.REFUNDED}
+			${ShopifyOrderFinancialStatus.voided}             | ${TransactionPaymentStatus.CANCELLED}
+		`(
+			`should change $status to $expected`,
+			({ status, expected }: { status: ShopifyOrderFinancialStatus; expected: TransactionPaymentStatus }) => {
+				expect(service.shopifyOrderFinancialStatusToEcommerceTransactionStatus(status)).toBe(expected)
+			},
+		)
+	})
+
+	describe('shopifyOrderFulfillmentStatusToEcommerceTransactionStatus', () => {
+		it.each`
+			status                                     | expected
+			${ShopifyOrderFulfillmentStatus.fulfilled} | ${TransactionFulfillmentStatus.SHIPPED}
+			${ShopifyOrderFulfillmentStatus.null}      | ${TransactionFulfillmentStatus.PENDING}
+			${ShopifyOrderFulfillmentStatus.partial}   | ${TransactionFulfillmentStatus.PARTIALLY_SHIPPED}
+			${ShopifyOrderFulfillmentStatus.restocked} | ${TransactionFulfillmentStatus.RETURNED}
+		`(
+			'should change $status to $expected',
+			({
+				status,
+				expected,
+			}: {
+				status: ShopifyOrderFulfillmentStatus
+				expected: TransactionFulfillmentStatus
+			}) => {
+				expect(service.shopifyOrderFulfillmentStatusToEcommerceTransactionStatus(status)).toBe(expected)
+			},
+		)
+	})
+
+	describe('shopifyDiscountCodesToEcommerceDicounts', () => {
+		it('should handle each discount type in a single call', async () => {
+			transactionsDiscountService.create
+				.mockResolvedValueOnce({
+					account_id: 1,
+					transaction_discount_id: 1,
+					type: TransactionDiscountType.FIXED,
+					code: 'fixed',
+					amount: 5,
+				})
+				.mockResolvedValueOnce({
+					account_id: 1,
+					transaction_discount_id: 2,
+					code: 'sale',
+					type: TransactionDiscountType.PERCENTAGE,
+					amount: 2,
+				})
+				.mockResolvedValueOnce({
+					account_id: 1,
+					transaction_discount_id: 3,
+					type: TransactionDiscountType.SHIPPING,
+					code: 'FREESHIP',
+					amount: 15,
+				})
+			expect(
+				await service.shopifyDiscountCodesToEcommerceDicounts(
+					[
+						{
+							code: 'fixed',
+							amount: '5',
+							type: ShopifyOrderDicountCodeType.fixed_amount,
+						},
+						{
+							code: 'sale',
+							amount: '2',
+							type: ShopifyOrderDicountCodeType.percentage,
+						},
+						{
+							code: 'FREESHIP',
+							amount: '15',
+							type: ShopifyOrderDicountCodeType.shipping,
+						},
+					],
+					1,
+					1,
+				),
+			).toEqual([
+				{
+					account_id: 1,
+					transaction_discount_id: 1,
+					type: TransactionDiscountType.FIXED,
+					code: 'fixed',
+					amount: 5,
+				},
+				{
+					account_id: 1,
+					transaction_discount_id: 2,
+					code: 'sale',
+					type: TransactionDiscountType.PERCENTAGE,
+					amount: 2,
+				},
+				{
+					account_id: 1,
+					transaction_discount_id: 3,
+					type: TransactionDiscountType.SHIPPING,
+					code: 'FREESHIP',
+					amount: 15,
+				},
+			])
+			expect(transactionsDiscountService.create).toHaveBeenNthCalledWith(1, {
+				account_id: 1,
+				transaction_id: 1,
+				code: 'fixed',
+				type: TransactionDiscountType.FIXED,
+				amount: 5,
+			})
+		})
+	})
+})

--- a/apps/shopify/src/modules/orders/orders.mapper.service.ts
+++ b/apps/shopify/src/modules/orders/orders.mapper.service.ts
@@ -147,31 +147,22 @@ export class ShopifyOrdersMapperService {
 		let has_changed = false
 		const changed: UpdateTransactionDto = {}
 
-		if (
-			transaction.payment_status !==
-			this.shopifyOrderFinancialStatusToEcommerceTransactionStatus(order.financial_status)
-		) {
-			changed.payment_status = this.shopifyOrderFinancialStatusToEcommerceTransactionStatus(
-				order.financial_status,
-			)
+		const newPaymentStatus = this.shopifyOrderFinancialStatusToEcommerceTransactionStatus(order.financial_status)
+		if (transaction.payment_status !== newPaymentStatus) {
+			changed.payment_status = newPaymentStatus
 			has_changed = true
 		}
 
-		if (
-			transaction.fulfillment_status !==
-			this.shopifyOrderFulfillmentStatusToEcommerceTransactionStatus(order.fulfillment_status)
-		) {
-			changed.fulfillment_status = this.shopifyOrderFulfillmentStatusToEcommerceTransactionStatus(
-				order.fulfillment_status,
-			)
+		const newFulfillmentStatus = this.shopifyOrderFulfillmentStatusToEcommerceTransactionStatus(
+			order.fulfillment_status,
+		)
+		if (transaction.fulfillment_status !== newFulfillmentStatus) {
+			changed.fulfillment_status = newFulfillmentStatus
 			has_changed = true
 		}
-
-		if (
-			order.total_shipping_price_set?.shop_money?.amount &&
-			Number(transaction.total_shipping) !== Number(order.total_shipping_price_set.shop_money.amount)
-		) {
-			changed.total_shipping = Number(order.total_shipping_price_set?.shop_money?.amount)
+		const orderTotal = Number(order.total_shipping_price_set?.shop_money?.amount ?? '0')
+		if (order.total_shipping_price_set?.shop_money?.amount && Number(transaction.total_shipping) !== orderTotal) {
+			changed.total_shipping = orderTotal
 			has_changed = true
 		}
 

--- a/apps/shopify/src/modules/orders/orders.mapper.service.ts
+++ b/apps/shopify/src/modules/orders/orders.mapper.service.ts
@@ -1,5 +1,12 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common'
-import { ShopifyOrder, ShopifyOrderDiscountCodes } from './orders.dto'
+import { InstalledApp } from '@juicyllama/app-store'
+import {
+	ContactsService,
+	ContactEmailService,
+	ContactAddressService,
+	ContactPhoneService,
+	Contact,
+	ContactAddress,
+} from '@juicyllama/crm'
 import {
 	Store,
 	Transaction,
@@ -11,26 +18,18 @@ import {
 	TransactionsService,
 	UpdateTransactionDto,
 } from '@juicyllama/ecommerce'
-import {
-	ContactsService,
-	ContactEmailService,
-	ContactAddressService,
-	ContactPhoneService,
-	Contact,
-	ContactAddress,
-} from '@juicyllama/crm'
+import { Injectable } from '@nestjs/common'
+import { ShopifyOrder, ShopifyOrderDiscountCodes } from './orders.dto'
 import { ShopifyOrderDicountCodeType, ShopifyOrderFinancialStatus, ShopifyOrderFulfillmentStatus } from './orders.enums'
-import { InstalledApp } from '@juicyllama/app-store'
 
 @Injectable()
 export class ShopifyOrdersMapperService {
 	constructor(
-		@Inject(forwardRef(() => ContactsService)) private readonly contactsService: ContactsService,
-		@Inject(forwardRef(() => ContactEmailService)) private readonly contactEmailService: ContactEmailService,
-		@Inject(forwardRef(() => ContactAddressService)) private readonly contactAddressService: ContactAddressService,
-		@Inject(forwardRef(() => ContactPhoneService)) private readonly contactPhoneService: ContactPhoneService,
-		@Inject(forwardRef(() => TransactionsService)) private readonly transactionsService: TransactionsService,
-		@Inject(forwardRef(() => TransactionDiscountsService))
+		private readonly contactsService: ContactsService,
+		private readonly contactEmailService: ContactEmailService,
+		private readonly contactAddressService: ContactAddressService,
+		private readonly contactPhoneService: ContactPhoneService,
+		private readonly transactionsService: TransactionsService,
 		private readonly transactionsDiscountService: TransactionDiscountsService,
 	) {}
 

--- a/apps/shopify/src/modules/orders/orders.module.ts
+++ b/apps/shopify/src/modules/orders/orders.module.ts
@@ -1,9 +1,5 @@
 import { Module, forwardRef } from '@nestjs/common'
-import { ConfigModule } from '@nestjs/config'
-import { Env, Logger } from '@juicyllama/utils'
-import Joi from 'joi'
-import shopifyConfig from '../../config/shopify.config'
-import { shopifyConfigJoi } from '../../config/shopify.config.joi'
+import { Logger } from '@juicyllama/utils'
 import { InstalledAppsModule, OAuthModule } from '@juicyllama/app-store'
 import { ShopifyOrdersService } from './orders.service'
 import { ShopifyOrdersController } from './orders.controller'
@@ -13,14 +9,10 @@ import { ShopifyOrdersCronService } from './orders.cron.service'
 import { StoresModule, TransactionDiscountsModule, TransactionsModule } from '@juicyllama/ecommerce'
 import { ShopifyOrdersMapperService } from './orders.mapper.service'
 import { ContactsModule } from '@juicyllama/crm'
+import { ShopifyProviderModule } from '../provider/provider.module'
 
 @Module({
 	imports: [
-		ConfigModule.forRoot({
-			isGlobal: true,
-			load: [shopifyConfig],
-			validationSchema: Env.IsNotTest() ? Joi.object(shopifyConfigJoi) : null,
-		}),
 		ScheduleModule.forRoot(),
 		forwardRef(() => ContactsModule),
 		forwardRef(() => OAuthModule),
@@ -28,6 +20,7 @@ import { ContactsModule } from '@juicyllama/crm'
 		forwardRef(() => StoresModule),
 		forwardRef(() => TransactionsModule),
 		forwardRef(() => TransactionDiscountsModule),
+		ShopifyProviderModule,
 	],
 	controllers: [ShopifyOrdersController, ShopifyOrdersCronController],
 	providers: [ShopifyOrdersService, ShopifyOrdersCronService, ShopifyOrdersMapperService, Logger],

--- a/apps/shopify/src/modules/orders/orders.module.ts
+++ b/apps/shopify/src/modules/orders/orders.module.ts
@@ -3,7 +3,6 @@ import { ContactsModule } from '@juicyllama/crm'
 import { StoresModule, TransactionDiscountsModule, TransactionsModule } from '@juicyllama/ecommerce'
 import { Logger } from '@juicyllama/utils'
 import { Module } from '@nestjs/common'
-import { ScheduleModule } from '@nestjs/schedule'
 import { ShopifyProviderModule } from '../provider/provider.module'
 import { ShopifyOrdersController } from './orders.controller'
 import { ShopifyOrdersCronController } from './orders.cron.controller'
@@ -13,7 +12,6 @@ import { ShopifyOrdersService } from './orders.service'
 
 @Module({
 	imports: [
-		ScheduleModule.forRoot(),
 		ContactsModule,
 		OAuthModule,
 		InstalledAppsModule,

--- a/apps/shopify/src/modules/orders/orders.module.ts
+++ b/apps/shopify/src/modules/orders/orders.module.ts
@@ -1,25 +1,25 @@
-import { Module, forwardRef } from '@nestjs/common'
-import { Logger } from '@juicyllama/utils'
 import { InstalledAppsModule, OAuthModule } from '@juicyllama/app-store'
-import { ShopifyOrdersService } from './orders.service'
+import { ContactsModule } from '@juicyllama/crm'
+import { StoresModule, TransactionDiscountsModule, TransactionsModule } from '@juicyllama/ecommerce'
+import { Logger } from '@juicyllama/utils'
+import { Module } from '@nestjs/common'
+import { ScheduleModule } from '@nestjs/schedule'
+import { ShopifyProviderModule } from '../provider/provider.module'
 import { ShopifyOrdersController } from './orders.controller'
 import { ShopifyOrdersCronController } from './orders.cron.controller'
-import { ScheduleModule } from '@nestjs/schedule'
 import { ShopifyOrdersCronService } from './orders.cron.service'
-import { StoresModule, TransactionDiscountsModule, TransactionsModule } from '@juicyllama/ecommerce'
 import { ShopifyOrdersMapperService } from './orders.mapper.service'
-import { ContactsModule } from '@juicyllama/crm'
-import { ShopifyProviderModule } from '../provider/provider.module'
+import { ShopifyOrdersService } from './orders.service'
 
 @Module({
 	imports: [
 		ScheduleModule.forRoot(),
-		forwardRef(() => ContactsModule),
-		forwardRef(() => OAuthModule),
-		forwardRef(() => InstalledAppsModule),
-		forwardRef(() => StoresModule),
-		forwardRef(() => TransactionsModule),
-		forwardRef(() => TransactionDiscountsModule),
+		ContactsModule,
+		OAuthModule,
+		InstalledAppsModule,
+		StoresModule,
+		TransactionsModule,
+		TransactionDiscountsModule,
 		ShopifyProviderModule,
 	],
 	controllers: [ShopifyOrdersController, ShopifyOrdersCronController],

--- a/apps/shopify/src/modules/orders/orders.service.spec.ts
+++ b/apps/shopify/src/modules/orders/orders.service.spec.ts
@@ -1,0 +1,294 @@
+import { AppScope, Oauth, OauthService } from '@juicyllama/app-store'
+import { Store, StoresService, TransactionsService } from '@juicyllama/ecommerce'
+import { Env, Logger } from '@juicyllama/utils'
+import { Test } from '@nestjs/testing'
+import { LATEST_API_VERSION, Shopify } from '@shopify/shopify-api'
+import { ShopifyOrdersMapperService } from './orders.mapper.service'
+import { ShopifyOrdersService } from './orders.service'
+import { SHOPIFY_PROVIDER_TOKEN } from '../provider/provider.constants'
+
+const getMock = jest.fn()
+
+describe('Shopify OrdersService', () => {
+	let service: ShopifyOrdersService
+	let logger: jest.Mocked<Logger>
+	let shopify: jest.Mocked<Shopify>
+	let oauthService: jest.Mocked<OauthService>
+	let transactionService: jest.Mocked<TransactionsService>
+	let storesService: jest.Mocked<StoresService>
+	let mapperService: jest.Mocked<ShopifyOrdersMapperService>
+
+	const installedApp = {
+		installed_app_id: 1234,
+		active: true,
+		app_id: 123,
+		name: 'test app',
+		scope: AppScope.ACCOUNT,
+		settings: {
+			SHOPIFY_SHOP_NAME: 'test',
+		},
+	}
+
+	beforeAll(async () => {
+		if (Env.IsNotTest()) {
+			throw new Error(`Test suite should not be ran outside the test environment`)
+		}
+		const modRef = await Test.createTestingModule({
+			providers: [
+				ShopifyOrdersService,
+				{
+					provide: Logger,
+					useValue: {
+						error: jest.fn(),
+						log: jest.fn(),
+					},
+				},
+				{
+					provide: SHOPIFY_PROVIDER_TOKEN,
+					useValue: {
+						clients: {
+							Rest: class {
+								get = getMock
+							},
+						},
+					},
+				},
+				{
+					provide: OauthService,
+					useValue: {
+						findOne: jest.fn(),
+					},
+				},
+				{
+					provide: TransactionsService,
+					useValue: {
+						findOne: jest.fn(),
+					},
+				},
+				{
+					provide: StoresService,
+					useValue: {
+						findOne: jest.fn(),
+					},
+				},
+				{
+					provide: ShopifyOrdersMapperService,
+					useValue: {
+						createEcommerceTransaction: jest.fn(),
+						updateEcommerceTransaction: jest.fn(),
+					},
+				},
+			],
+		}).compile()
+		service = modRef.get(ShopifyOrdersService)
+		logger = modRef.get(Logger)
+		mapperService = modRef.get(ShopifyOrdersMapperService)
+		storesService = modRef.get(StoresService)
+		transactionService = modRef.get(TransactionsService)
+		oauthService = modRef.get(OauthService)
+	})
+
+	afterEach(() => {
+		jest.clearAllMocks()
+	})
+
+	it('should create the OrdersService', () => {
+		expect(service).toBeDefined()
+	})
+
+	describe('list orders', () => {
+		it('should throw an error on no Oauth', async () => {
+			oauthService.findOne.mockResolvedValueOnce(null as unknown as Promise<Oauth>)
+			await expect(service.listOrders(installedApp, { api_version: LATEST_API_VERSION })).rejects.toThrow(
+				new Error('Oauth not found'),
+			)
+			expect(logger.error).toHaveBeenNthCalledWith(1, `[app::shopify::orders::listOrders] Oauth not found`, {
+				installed_app_id: 1234,
+			})
+		})
+		it('should throw an error on no store being passed, and none found', async () => {
+			oauthService.findOne.mockResolvedValueOnce({
+				oauth_id: 12,
+				access_token: 'access_token',
+				installed_app: installedApp,
+			})
+			storesService.findOne.mockResolvedValue(null as unknown as Store)
+			await expect(service.listOrders(installedApp, { api_version: LATEST_API_VERSION })).rejects.toThrow(
+				new Error('Store not found'),
+			)
+			expect(oauthService.findOne).toHaveBeenCalledTimes(1)
+			expect(storesService.findOne).toHaveBeenCalledTimes(1)
+			expect(logger.error).toHaveBeenNthCalledWith(1, '[app::shopify::orders::listOrders] Store not found', {
+				installed_app_id: 1234,
+			})
+		})
+		it('should get one page worth of orders', async () => {
+			oauthService.findOne.mockResolvedValueOnce({
+				oauth_id: 12,
+				access_token: 'access_token',
+				installed_app: installedApp,
+			})
+			storesService.findOne.mockResolvedValue({
+				account_id: 12,
+				store_id: 24,
+			})
+			const now = new Date()
+			getMock.mockResolvedValueOnce({
+				body: {
+					orders: [
+						{
+							id: 1,
+							admin_graphql_api_id: 1,
+							app_id: 1234,
+							buyer_accepts_marketing: true,
+							checkout_id: 2,
+							created_at: now,
+							currency: 'USD',
+							name: 'Test Order',
+							number: 5,
+							taxes_included: true,
+							test: true,
+							subtotal_price: 50,
+							total_outstanding: 50,
+							total_price: 50,
+							total_tax: 0,
+							updated_at: now,
+						},
+					],
+				},
+				pageInfo: {},
+			})
+			expect(await service.listOrders(installedApp, { api_version: LATEST_API_VERSION })).toEqual([
+				{
+					id: 1,
+					admin_graphql_api_id: 1,
+					app_id: 1234,
+					buyer_accepts_marketing: true,
+					checkout_id: 2,
+					created_at: now,
+					currency: 'USD',
+					name: 'Test Order',
+					number: 5,
+					taxes_included: true,
+					test: true,
+					subtotal_price: 50,
+					total_outstanding: 50,
+					total_price: 50,
+					total_tax: 0,
+					updated_at: now,
+				},
+			])
+			expect(getMock).toHaveBeenCalledTimes(1)
+			expect(logger.log).toHaveBeenNthCalledWith(1, '[app::shopify::orders::listOrders] 1 Orders found')
+		})
+		it('should get multiple pages or orders', async () => {
+			oauthService.findOne.mockResolvedValueOnce({
+				oauth_id: 12,
+				access_token: 'access_token',
+				installed_app: installedApp,
+			})
+			storesService.findOne.mockResolvedValue({
+				account_id: 12,
+				store_id: 24,
+			})
+			const now = new Date()
+			getMock
+				.mockResolvedValueOnce({
+					body: {
+						orders: [
+							{
+								id: 1,
+								admin_graphql_api_id: 1,
+								app_id: 1234,
+								buyer_accepts_marketing: true,
+								checkout_id: 2,
+								created_at: now,
+								currency: 'USD',
+								name: 'Test Order',
+								number: 5,
+								taxes_included: true,
+								test: true,
+								subtotal_price: 50,
+								total_outstanding: 50,
+								total_price: 50,
+								total_tax: 0,
+								updated_at: now,
+							},
+						],
+					},
+					pageInfo: {
+						nextPage: {
+							query: {},
+						},
+					},
+				})
+				.mockResolvedValueOnce({
+					body: {
+						orders: [
+							{
+								id: 2,
+								admin_graphql_api_id: 2,
+								app_id: 1234,
+								buyer_accepts_marketing: true,
+								checkout_id: 2,
+								created_at: now,
+								currency: 'USD',
+								name: 'Test Order',
+								number: 5,
+								taxes_included: true,
+								test: true,
+								subtotal_price: 50,
+								total_outstanding: 50,
+								total_price: 50,
+								total_tax: 0,
+								updated_at: now,
+							},
+						],
+					},
+					pageInfo: {},
+				})
+			expect(await service.listOrders(installedApp, { api_version: LATEST_API_VERSION })).toEqual([
+				{
+					id: 1,
+					admin_graphql_api_id: 1,
+					app_id: 1234,
+					buyer_accepts_marketing: true,
+					checkout_id: 2,
+					created_at: now,
+					currency: 'USD',
+					name: 'Test Order',
+					number: 5,
+					taxes_included: true,
+					test: true,
+					subtotal_price: 50,
+					total_outstanding: 50,
+					total_price: 50,
+					total_tax: 0,
+					updated_at: now,
+				},
+				{
+					id: 2,
+					admin_graphql_api_id: 2,
+					app_id: 1234,
+					buyer_accepts_marketing: true,
+					checkout_id: 2,
+					created_at: now,
+					currency: 'USD',
+					name: 'Test Order',
+					number: 5,
+					taxes_included: true,
+					test: true,
+					subtotal_price: 50,
+					total_outstanding: 50,
+					total_price: 50,
+					total_tax: 0,
+					updated_at: now,
+				},
+			])
+			expect(getMock).toHaveBeenCalledTimes(2)
+			expect(logger.log).toHaveBeenNthCalledWith(2, '[app::shopify::orders::listOrders] 2 Orders found')
+		})
+	})
+	describe('syncOrders', () => {})
+	describe('addOrUpdateOrder', () => {})
+})

--- a/apps/shopify/src/modules/orders/orders.service.ts
+++ b/apps/shopify/src/modules/orders/orders.service.ts
@@ -52,7 +52,7 @@ export class ShopifyOrdersService {
 
 		const session = ShopifySession(installed_app, oath)
 
-		const orders = <ShopifyOrder[]>[]
+		const orders: ShopifyOrder[] = []
 		let pageInfo
 
 		const client = new this.shopify.clients.Rest({

--- a/apps/shopify/src/modules/orders/orders.service.ts
+++ b/apps/shopify/src/modules/orders/orders.service.ts
@@ -1,7 +1,7 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common'
 import { InstalledApp, OauthService } from '@juicyllama/app-store'
 import { Store, StoresService, Transaction, TransactionsService } from '@juicyllama/ecommerce'
 import { Logger } from '@juicyllama/utils'
+import { Injectable } from '@nestjs/common'
 import { Shopify } from '@shopify/shopify-api'
 import { ShopifySession } from '../../config/shopify.config'
 import { InjectShopify } from '../provider/provider.constants'
@@ -11,12 +11,11 @@ import { ShopifyOrdersMapperService } from './orders.mapper.service'
 @Injectable()
 export class ShopifyOrdersService {
 	constructor(
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
+		private readonly logger: Logger,
 		@InjectShopify() private readonly shopify: Shopify,
-		@Inject(forwardRef(() => OauthService)) private readonly oauthService: OauthService,
-		@Inject(forwardRef(() => TransactionsService)) private readonly transactionsService: TransactionsService,
-		@Inject(forwardRef(() => StoresService)) private readonly storesService: StoresService,
-		@Inject(forwardRef(() => ShopifyOrdersMapperService))
+		private readonly oauthService: OauthService,
+		private readonly transactionsService: TransactionsService,
+		private readonly storesService: StoresService,
 		private readonly mapperService: ShopifyOrdersMapperService,
 	) {}
 

--- a/apps/shopify/src/modules/orders/orders.service.ts
+++ b/apps/shopify/src/modules/orders/orders.service.ts
@@ -1,17 +1,18 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common'
-import { Shopify, ShopifySession } from '../../config/shopify.config'
-import { Logger } from '@juicyllama/utils'
-import { ConfigService } from '@nestjs/config'
 import { InstalledApp, OauthService } from '@juicyllama/app-store'
-import { ShopifyOrder, ShopifyRestListOrders } from './orders.dto'
 import { Store, StoresService, Transaction, TransactionsService } from '@juicyllama/ecommerce'
+import { Logger } from '@juicyllama/utils'
+import { Shopify } from '@shopify/shopify-api'
+import { ShopifySession } from '../../config/shopify.config'
+import { InjectShopify } from '../provider/provider.constants'
+import { ShopifyOrder, ShopifyRestListOrders } from './orders.dto'
 import { ShopifyOrdersMapperService } from './orders.mapper.service'
 
 @Injectable()
 export class ShopifyOrdersService {
 	constructor(
 		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
-		@Inject(forwardRef(() => ConfigService)) private readonly configService: ConfigService,
+		@InjectShopify() private readonly shopify: Shopify,
 		@Inject(forwardRef(() => OauthService)) private readonly oauthService: OauthService,
 		@Inject(forwardRef(() => TransactionsService)) private readonly transactionsService: TransactionsService,
 		@Inject(forwardRef(() => StoresService)) private readonly storesService: StoresService,
@@ -30,7 +31,6 @@ export class ShopifyOrdersService {
 	): Promise<ShopifyOrder[]> {
 		const domain = 'app::shopify::orders::listOrders'
 
-		const shopify = Shopify(this.configService.get('shopify'))
 		const oath = await this.oauthService.findOne({ where: { installed_app_id: installed_app.installed_app_id } })
 
 		if (!oath) {
@@ -56,7 +56,7 @@ export class ShopifyOrdersService {
 		const orders = <ShopifyOrder[]>[]
 		let pageInfo
 
-		const client = new shopify.clients.Rest({
+		const client = new this.shopify.clients.Rest({
 			session,
 			apiVersion: options.api_version,
 		})

--- a/apps/shopify/src/modules/provider/provider.constants.ts
+++ b/apps/shopify/src/modules/provider/provider.constants.ts
@@ -1,0 +1,5 @@
+import { Inject } from '@nestjs/common'
+
+export const SHOPIFY_PROVIDER_TOKEN = 'TOKEN:SHOPIFY_PROVIDER'
+
+export const InjectShopify = () => Inject(SHOPIFY_PROVIDER_TOKEN)

--- a/apps/shopify/src/modules/provider/provider.module.ts
+++ b/apps/shopify/src/modules/provider/provider.module.ts
@@ -1,19 +1,10 @@
 import { Module } from '@nestjs/common'
-import { ConfigModule, ConfigService } from '@nestjs/config'
-import { Env } from '@juicyllama/utils'
-import Joi from 'joi'
-import shopifyConfig, { Shopify } from '../../config/shopify.config'
-import { shopifyConfigJoi } from '../../config/shopify.config.joi'
+import { ConfigService } from '@nestjs/config'
+import { Shopify } from '../../config/shopify.config'
 import { SHOPIFY_PROVIDER_TOKEN } from './provider.constants'
 
 @Module({
-	imports: [
-		ConfigModule.forRoot({
-			isGlobal: true,
-			load: [shopifyConfig],
-			validationSchema: Env.IsNotTest() ? Joi.object(shopifyConfigJoi) : null,
-		}),
-	],
+	imports: [],
 	providers: [
 		{
 			provide: SHOPIFY_PROVIDER_TOKEN,

--- a/apps/shopify/src/modules/provider/provider.module.ts
+++ b/apps/shopify/src/modules/provider/provider.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common'
+import { ConfigModule, ConfigService } from '@nestjs/config'
+import { Env } from '@juicyllama/utils'
+import Joi from 'joi'
+import shopifyConfig, { Shopify } from '../../config/shopify.config'
+import { shopifyConfigJoi } from '../../config/shopify.config.joi'
+import { SHOPIFY_PROVIDER_TOKEN } from './provider.constants'
+
+@Module({
+	imports: [
+		ConfigModule.forRoot({
+			isGlobal: true,
+			load: [shopifyConfig],
+			validationSchema: Env.IsNotTest() ? Joi.object(shopifyConfigJoi) : null,
+		}),
+	],
+	providers: [
+		{
+			provide: SHOPIFY_PROVIDER_TOKEN,
+			inject: [ConfigService],
+			useFactory: (config: ConfigService) => Shopify(config.get('shopify')),
+		},
+	],
+	exports: [SHOPIFY_PROVIDER_TOKEN],
+})
+export class ShopifyProviderModule {}

--- a/apps/shopify/src/modules/shop/shop.controller.ts
+++ b/apps/shopify/src/modules/shop/shop.controller.ts
@@ -1,16 +1,16 @@
-import { Controller, forwardRef, Inject, Query, Body, Post } from '@nestjs/common'
-import { ApiHideProperty } from '@nestjs/swagger'
-import { Logger } from '@juicyllama/utils'
 import { InstalledAppsService } from '@juicyllama/app-store'
 import { Transaction } from '@juicyllama/ecommerce'
+import { Logger } from '@juicyllama/utils'
+import { Controller, Query, Body, Post } from '@nestjs/common'
+import { ApiHideProperty } from '@nestjs/swagger'
 import { ShopifyShopService } from './shop.service'
 
 @Controller('app/shopify/shop')
 export class ShopifyShopController {
 	constructor(
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
-		@Inject(forwardRef(() => ShopifyShopService)) private readonly shopifyShopService: ShopifyShopService,
-		@Inject(forwardRef(() => InstalledAppsService)) private readonly installedAppsService: InstalledAppsService,
+		private readonly logger: Logger,
+		private readonly shopifyShopService: ShopifyShopService,
+		private readonly installedAppsService: InstalledAppsService,
 	) {}
 
 	/**

--- a/apps/shopify/src/modules/shop/shop.module.ts
+++ b/apps/shopify/src/modules/shop/shop.module.ts
@@ -1,26 +1,13 @@
-import { Module, forwardRef } from '@nestjs/common'
-import { ConfigModule } from '@nestjs/config'
-import { Env, Logger } from '@juicyllama/utils'
-import Joi from 'joi'
-import shopifyConfig from '../../config/shopify.config'
-import { shopifyConfigJoi } from '../../config/shopify.config.joi'
 import { InstalledAppsModule } from '@juicyllama/app-store'
-import { ShopifyShopService } from './shop.service'
-import { ShopifyShopController } from './shop.controller'
-import { ScheduleModule } from '@nestjs/schedule'
 import { StoresModule } from '@juicyllama/ecommerce'
+import { Logger } from '@juicyllama/utils'
+import { Module } from '@nestjs/common'
+import { ScheduleModule } from '@nestjs/schedule'
+import { ShopifyShopController } from './shop.controller'
+import { ShopifyShopService } from './shop.service'
 
 @Module({
-	imports: [
-		ConfigModule.forRoot({
-			isGlobal: true,
-			load: [shopifyConfig],
-			validationSchema: Env.IsNotTest() ? Joi.object(shopifyConfigJoi) : null,
-		}),
-		ScheduleModule.forRoot(),
-		forwardRef(() => InstalledAppsModule),
-		forwardRef(() => StoresModule),
-	],
+	imports: [ScheduleModule.forRoot(), InstalledAppsModule, StoresModule],
 	controllers: [ShopifyShopController],
 	providers: [ShopifyShopService, Logger],
 	exports: [ShopifyShopService],

--- a/apps/shopify/src/modules/shop/shop.module.ts
+++ b/apps/shopify/src/modules/shop/shop.module.ts
@@ -2,12 +2,11 @@ import { InstalledAppsModule } from '@juicyllama/app-store'
 import { StoresModule } from '@juicyllama/ecommerce'
 import { Logger } from '@juicyllama/utils'
 import { Module } from '@nestjs/common'
-import { ScheduleModule } from '@nestjs/schedule'
 import { ShopifyShopController } from './shop.controller'
 import { ShopifyShopService } from './shop.service'
 
 @Module({
-	imports: [ScheduleModule.forRoot(), InstalledAppsModule, StoresModule],
+	imports: [InstalledAppsModule, StoresModule],
 	controllers: [ShopifyShopController],
 	providers: [ShopifyShopService, Logger],
 	exports: [ShopifyShopService],

--- a/apps/shopify/src/modules/shop/shop.service.ts
+++ b/apps/shopify/src/modules/shop/shop.service.ts
@@ -1,14 +1,14 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common'
-import { Logger } from '@juicyllama/utils'
 import { InstalledApp, InstalledAppsService } from '@juicyllama/app-store'
 import { Store, StoresService } from '@juicyllama/ecommerce'
+import { Logger } from '@juicyllama/utils'
+import { Injectable } from '@nestjs/common'
 
 @Injectable()
 export class ShopifyShopService {
 	constructor(
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
-		@Inject(forwardRef(() => InstalledAppsService)) private readonly installedAppService: InstalledAppsService,
-		@Inject(forwardRef(() => StoresService)) private readonly storesService: StoresService,
+		private readonly logger: Logger,
+		private readonly installedAppService: InstalledAppsService,
+		private readonly storesService: StoresService,
 	) {}
 
 	/**

--- a/apps/shopify/src/modules/shopify.installation.ts
+++ b/apps/shopify/src/modules/shopify.installation.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Inject, Injectable, OnModuleInit } from '@nestjs/common'
+import { Injectable, OnModuleInit } from '@nestjs/common'
 import { Logger } from '@juicyllama/utils'
 import {
 	AppCategory,
@@ -12,8 +12,8 @@ import {
 @Injectable()
 export class ShopifyInstallationService implements OnModuleInit {
 	constructor(
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
-		@Inject(forwardRef(() => AppsService)) private readonly appsService: AppsService,
+		private readonly logger: Logger,
+		private readonly appsService: AppsService,
 	) {}
 
 	async onModuleInit() {

--- a/apps/shopify/src/modules/shopify.installation.ts
+++ b/apps/shopify/src/modules/shopify.installation.ts
@@ -17,7 +17,7 @@ export class ShopifyInstallationService implements OnModuleInit {
 	) {}
 
 	async onModuleInit() {
-		try{
+		try {
 			const app = await this.appsService.findOne({
 				where: {
 					integration_name: AppStoreIntegrationName.shopify,
@@ -59,7 +59,6 @@ export class ShopifyInstallationService implements OnModuleInit {
 					],
 				})
 			}
-
 		} catch (e: any) {
 			this.logger.error(e.message, e)
 		}

--- a/apps/shopify/src/modules/shopify.module.ts
+++ b/apps/shopify/src/modules/shopify.module.ts
@@ -1,30 +1,13 @@
-import { forwardRef, Module } from '@nestjs/common'
-import { ConfigModule } from '@nestjs/config'
-import { Env, Logger } from '@juicyllama/utils'
-import Joi from 'joi'
-import shopifyConfig from '../config/shopify.config'
-import { shopifyConfigJoi } from '../config/shopify.config.joi'
-import { ShopifyAuthModule } from './auth/auth.module'
-import { ShopifyInstallationService } from './shopify.installation'
 import { AppsModule } from '@juicyllama/app-store'
-import { databaseConfig } from '@juicyllama/core'
-import { TypeOrmModule } from '@nestjs/typeorm'
+import { Logger } from '@juicyllama/utils'
+import { Module } from '@nestjs/common'
+import { ShopifyAuthModule } from './auth/auth.module'
 import { ShopifyOrdersModule } from './orders/orders.module'
+import { ShopifyInstallationService } from './shopify.installation'
 import { ShopifyWebhooksModule } from './webhooks/webhooks.module'
 
 @Module({
-	imports: [
-		ConfigModule.forRoot({
-			isGlobal: true,
-			load: [shopifyConfig],
-			validationSchema: Env.IsNotTest() ? Joi.object(shopifyConfigJoi) : null,
-		}),
-		TypeOrmModule.forRoot(databaseConfig()),
-		forwardRef(() => AppsModule),
-		forwardRef(() => ShopifyAuthModule),
-		forwardRef(() => ShopifyOrdersModule),
-		forwardRef(() => ShopifyWebhooksModule),
-	],
+	imports: [AppsModule, ShopifyAuthModule, ShopifyOrdersModule, ShopifyWebhooksModule],
 	providers: [ShopifyInstallationService, Logger],
 })
 export class ShopifyModule {}

--- a/apps/shopify/src/modules/shopify.module.ts
+++ b/apps/shopify/src/modules/shopify.module.ts
@@ -3,11 +3,13 @@ import { Logger } from '@juicyllama/utils'
 import { Module } from '@nestjs/common'
 import { ShopifyAuthModule } from './auth/auth.module'
 import { ShopifyOrdersModule } from './orders/orders.module'
+import { ShopifyProviderModule } from './provider/provider.module'
 import { ShopifyInstallationService } from './shopify.installation'
 import { ShopifyWebhooksModule } from './webhooks/webhooks.module'
 
 @Module({
-	imports: [AppsModule, ShopifyAuthModule, ShopifyOrdersModule, ShopifyWebhooksModule],
+	imports: [AppsModule, ShopifyAuthModule, ShopifyOrdersModule, ShopifyWebhooksModule, ShopifyProviderModule],
 	providers: [ShopifyInstallationService, Logger],
+	exports: [ShopifyProviderModule],
 })
 export class ShopifyModule {}

--- a/apps/shopify/src/modules/shopify.spec.ts
+++ b/apps/shopify/src/modules/shopify.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { ConfigModule } from '@nestjs/config'
+import { Env } from '@juicyllama/utils'
+import { ShopifyModule } from './shopify.module'
+import { ShopifyInstallationService } from './shopify.installation'
+import shopifyConfig from '../config/shopify.config'
+import { shopifyConfigJoi } from '../config/shopify.config.joi'
+describe('Shopify', () => {
+	let moduleRef: TestingModule
+
+	beforeAll(async () => {
+		if (Env.IsNotTest()) {
+			throw new Error(`Test suite should not be ran outside the test environment`)
+		}
+
+		moduleRef = await Test.createTestingModule({
+			imports: [
+				ConfigModule.forRoot({
+					isGlobal: true,
+					load: [shopifyConfig],
+					validationSchema: Env.IsNotTest() ? shopifyConfigJoi : null,
+				}),
+				ShopifyModule,
+			],
+		}).compile()
+	}, 180000)
+	it('should allow for the use of the ShopifyModule', () => {
+		expect(moduleRef.get(ShopifyInstallationService, { strict: false })).toBeDefined()
+	})
+})

--- a/apps/shopify/src/modules/webhooks/webhooks.module.ts
+++ b/apps/shopify/src/modules/webhooks/webhooks.module.ts
@@ -1,23 +1,12 @@
 import { Module, forwardRef } from '@nestjs/common'
-import { ConfigModule } from '@nestjs/config'
-import { Env, Logger } from '@juicyllama/utils'
-import Joi from 'joi'
-import shopifyConfig from '../../config/shopify.config'
-import { shopifyConfigJoi } from '../../config/shopify.config.joi'
+import { Logger } from '@juicyllama/utils'
 import { InstalledAppsModule, OAuthModule } from '@juicyllama/app-store'
 import { ShopifyWebhooksService } from './webhooks.service'
 import { ShopifyWebhooksController } from './webhooks.controller'
+import { ShopifyProviderModule } from '../provider/provider.module'
 
 @Module({
-	imports: [
-		ConfigModule.forRoot({
-			isGlobal: true,
-			load: [shopifyConfig],
-			validationSchema: Env.IsNotTest() ? Joi.object(shopifyConfigJoi) : null,
-		}),
-		forwardRef(() => OAuthModule),
-		forwardRef(() => InstalledAppsModule),
-	],
+	imports: [forwardRef(() => OAuthModule), forwardRef(() => InstalledAppsModule), ShopifyProviderModule],
 	controllers: [ShopifyWebhooksController],
 	providers: [ShopifyWebhooksService, Logger],
 	exports: [ShopifyWebhooksService],

--- a/apps/shopify/src/modules/webhooks/webhooks.module.ts
+++ b/apps/shopify/src/modules/webhooks/webhooks.module.ts
@@ -1,12 +1,12 @@
-import { Module, forwardRef } from '@nestjs/common'
-import { Logger } from '@juicyllama/utils'
 import { InstalledAppsModule, OAuthModule } from '@juicyllama/app-store'
+import { Logger } from '@juicyllama/utils'
+import { Module } from '@nestjs/common'
 import { ShopifyWebhooksService } from './webhooks.service'
 import { ShopifyWebhooksController } from './webhooks.controller'
 import { ShopifyProviderModule } from '../provider/provider.module'
 
 @Module({
-	imports: [forwardRef(() => OAuthModule), forwardRef(() => InstalledAppsModule), ShopifyProviderModule],
+	imports: [OAuthModule, InstalledAppsModule, ShopifyProviderModule],
 	controllers: [ShopifyWebhooksController],
 	providers: [ShopifyWebhooksService, Logger],
 	exports: [ShopifyWebhooksService],

--- a/apps/shopify/src/modules/webhooks/webhooks.service.spec.ts
+++ b/apps/shopify/src/modules/webhooks/webhooks.service.spec.ts
@@ -1,0 +1,208 @@
+import { AppScope, OauthService } from '@juicyllama/app-store'
+import { Env, Logger } from '@juicyllama/utils'
+import { Test } from '@nestjs/testing'
+import { LATEST_API_VERSION, Shopify } from '@shopify/shopify-api'
+import { ShopifyWebhooksService } from './webhooks.service'
+import { SHOPIFY_PROVIDER_TOKEN } from '../provider/provider.constants'
+import { ShopifyWebhooksTopicRoutes, ShopifyWebhooksTopics } from './webhooks.enums'
+import { InstalledApp } from '@juicyllama/app-store'
+
+const getMock = jest.fn()
+const putMock = jest.fn()
+const postMock = jest.fn()
+
+describe('Shopify WebhookService', () => {
+	let service: ShopifyWebhooksService
+	let logger: jest.Mocked<Logger>
+	let oauthService: jest.Mocked<OauthService>
+	let shopify: jest.Mocked<Shopify>
+	const installedApp: InstalledApp = {
+		installed_app_id: 1234,
+		settings: { SHOPIFY_SHOP_NAME: 'installed_app_shopify_name' },
+		app_id: 123456,
+		active: true,
+		name: 'test app',
+		scope: AppScope.ACCOUNT,
+	}
+	beforeAll(async () => {
+		if (Env.IsNotTest()) {
+			throw new Error('Tests should only be ran in the test environment')
+		}
+		const modRef = await Test.createTestingModule({
+			providers: [
+				ShopifyWebhooksService,
+				{
+					provide: Logger,
+					useValue: {
+						log: jest.fn(),
+					},
+				},
+				{
+					provide: OauthService,
+					useValue: {
+						findOne: jest.fn(),
+					},
+				},
+				{
+					provide: SHOPIFY_PROVIDER_TOKEN,
+					useValue: {
+						clients: {
+							Rest: class {
+								get = getMock
+								put = putMock
+								post = postMock
+							},
+						},
+					},
+				},
+			],
+		}).compile()
+		service = modRef.get(ShopifyWebhooksService)
+		logger = modRef.get(Logger)
+		oauthService = modRef.get(OauthService)
+		shopify = modRef.get(SHOPIFY_PROVIDER_TOKEN)
+	})
+
+	afterEach(() => {
+		jest.clearAllMocks()
+	})
+
+	it('should define and create the service', () => {
+		expect(service).toBeDefined()
+	})
+	describe('createWebhook', () => {
+		it('should create a new webhook', async () => {
+			oauthService.findOne.mockResolvedValueOnce({
+				oauth_id: 123,
+				access_token: 'oauth access token',
+				installed_app: installedApp,
+			})
+			oauthService.findOne.mockResolvedValueOnce({
+				oauth_id: 123,
+				access_token: 'oauth access token',
+				installed_app: installedApp,
+			})
+			getMock.mockResolvedValueOnce({
+				body: {
+					webhooks: [],
+				},
+			})
+			postMock.mockResolvedValueOnce({
+				body: {
+					webhook: 'This is the response webhook data from creating a new webhook',
+				},
+			})
+			expect(
+				await service.createWebhook(
+					installedApp,
+					{
+						api_version: LATEST_API_VERSION,
+					},
+					{
+						topic: ShopifyWebhooksTopics['customers/data_request'],
+					},
+				),
+			).toEqual('This is the response webhook data from creating a new webhook')
+			expect(oauthService.findOne).toHaveBeenCalledTimes(2)
+			expect(logger.log).toHaveBeenCalledTimes(2)
+			expect(getMock).toHaveBeenCalledTimes(1)
+			expect(getMock).toHaveBeenCalledWith({
+				path: 'webhooks',
+				query: {
+					api_version: LATEST_API_VERSION,
+					topic: ShopifyWebhooksTopics['customers/data_request'],
+				},
+			})
+			expect(postMock).toHaveBeenCalledTimes(1)
+			expect(postMock).toHaveBeenCalledWith({
+				path: 'webhooks',
+				data: {
+					webhook: {
+						format: 'json',
+						topic: ShopifyWebhooksTopics['customers/data_request'],
+						address: `${process.env.BASE_URL_API}/${ShopifyWebhooksTopicRoutes['customers/data_request']}?installed_app_id=1234`,
+					},
+				},
+			})
+		})
+		it('should update the existing client webhooks', async () => {
+			oauthService.findOne.mockResolvedValueOnce({
+				oauth_id: 123,
+				access_token: 'oauth access token',
+				installed_app: installedApp,
+			})
+			oauthService.findOne.mockResolvedValueOnce({
+				oauth_id: 123,
+				access_token: 'oauth access token',
+				installed_app: installedApp,
+			})
+			getMock.mockResolvedValueOnce({
+				body: {
+					webhooks: [
+						{
+							id: 1234,
+						},
+					],
+				},
+			})
+			putMock.mockResolvedValueOnce({
+				body: {
+					webhook: 'This is the response webhook data from updating a webhook',
+				},
+			})
+			expect(
+				await service.createWebhook(
+					installedApp,
+					{
+						api_version: LATEST_API_VERSION,
+					},
+					{
+						topic: ShopifyWebhooksTopics['customers/data_request'],
+					},
+				),
+			).toEqual('This is the response webhook data from updating a webhook')
+			expect(oauthService.findOne).toHaveBeenCalledTimes(2)
+			expect(logger.log).toHaveBeenCalledTimes(2)
+			expect(getMock).toHaveBeenCalledTimes(1)
+			expect(getMock).toHaveBeenCalledWith({
+				path: 'webhooks',
+				query: {
+					api_version: LATEST_API_VERSION,
+					topic: ShopifyWebhooksTopics['customers/data_request'],
+				},
+			})
+			expect(putMock).toHaveBeenCalledTimes(1)
+			expect(putMock).toHaveBeenCalledWith({
+				path: 'webhooks/1234',
+				data: {
+					webhook: {
+						address: `${process.env.BASE_URL_API}/${ShopifyWebhooksTopicRoutes['customers/data_request']}?installed_app_id=1234`,
+					},
+				},
+			})
+		})
+	})
+	describe('getWebhooks', () => {
+		it('should return the respective webhooks', async () => {
+			oauthService.findOne.mockResolvedValueOnce({
+				oauth_id: 123,
+				access_token: 'oauth_access_token',
+				installed_app: installedApp,
+			})
+			getMock.mockResolvedValueOnce({
+				body: {
+					webhooks: [],
+				},
+			})
+			expect(
+				await service.getWebhooks(installedApp, {
+					api_version: LATEST_API_VERSION,
+					topic: ShopifyWebhooksTopics['customers/data_request'],
+				}),
+			).toEqual([])
+			expect(oauthService.findOne).toHaveBeenCalledTimes(1)
+			expect(getMock).toHaveBeenCalledTimes(1)
+			expect(logger.log).toHaveBeenCalledWith('[app::shopify::webhook::getWebhooks] 0 Webhooks found')
+		})
+	})
+})

--- a/apps/shopify/src/modules/webhooks/webhooks.service.ts
+++ b/apps/shopify/src/modules/webhooks/webhooks.service.ts
@@ -1,6 +1,6 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common'
 import { InstalledApp, OauthService } from '@juicyllama/app-store'
 import { Logger } from '@juicyllama/utils'
+import { Injectable } from '@nestjs/common'
 import { ApiVersion, Shopify } from '@shopify/shopify-api'
 import { ShopifySession } from '../../config/shopify.config'
 import { InjectShopify } from '../provider/provider.constants'
@@ -11,8 +11,8 @@ import { ShopifyWebhooksTopicRoutes, ShopifyWebhooksTopics } from './webhooks.en
 @Injectable()
 export class ShopifyWebhooksService {
 	constructor(
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
-		@Inject(forwardRef(() => OauthService)) private readonly oauthService: OauthService,
+		private readonly logger: Logger,
+		private readonly oauthService: OauthService,
 		@InjectShopify() private readonly shopify: Shopify,
 	) {}
 

--- a/apps/shopify/src/sandbox/sandbox.module.ts
+++ b/apps/shopify/src/sandbox/sandbox.module.ts
@@ -2,8 +2,8 @@ import { databaseConfig } from '@juicyllama/core'
 import { Env } from '@juicyllama/utils'
 import { Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
+import { ScheduleModule } from '@nestjs/schedule'
 import { TypeOrmModule } from '@nestjs/typeorm'
-import Joi from 'joi'
 import shopifyConfig from '../config/shopify.config'
 import { shopifyConfigJoi } from '../config/shopify.config.joi'
 import { ShopifyModule } from '../modules/shopify.module'
@@ -14,9 +14,10 @@ import { ShopifyModule } from '../modules/shopify.module'
 		ConfigModule.forRoot({
 			isGlobal: true,
 			load: [shopifyConfig],
-			validationSchema: Env.IsNotTest() ? Joi.object(shopifyConfigJoi) : null,
+			validationSchema: Env.IsNotTest() ? shopifyConfigJoi : null,
 		}),
 		TypeOrmModule.forRoot(databaseConfig()),
+		ScheduleModule.forRoot(),
 	],
 })
 export class SandboxModule {}

--- a/apps/shopify/src/sandbox/sandbox.module.ts
+++ b/apps/shopify/src/sandbox/sandbox.module.ts
@@ -1,7 +1,22 @@
-import { forwardRef, Module } from '@nestjs/common'
+import { databaseConfig } from '@juicyllama/core'
+import { Env } from '@juicyllama/utils'
+import { Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import Joi from 'joi'
+import shopifyConfig from '../config/shopify.config'
+import { shopifyConfigJoi } from '../config/shopify.config.joi'
 import { ShopifyModule } from '../modules/shopify.module'
 
 @Module({
-	imports: [forwardRef(() => ShopifyModule)],
+	imports: [
+		ShopifyModule,
+		ConfigModule.forRoot({
+			isGlobal: true,
+			load: [shopifyConfig],
+			validationSchema: Env.IsNotTest() ? Joi.object(shopifyConfigJoi) : null,
+		}),
+		TypeOrmModule.forRoot(databaseConfig()),
+	],
 })
 export class SandboxModule {}

--- a/common/docs/content/apps/shopify/modules/provider.md
+++ b/common/docs/content/apps/shopify/modules/provider.md
@@ -1,0 +1,29 @@
+# Using the Shopify Instance Directly
+
+To make use of the `Shopify` instance directly, import the module into your project:
+
+```typescript
+// foo.module.ts
+import { ShopifyProviderModule } from '@juicyllamma/app-shopify'
+
+@Module({
+	imports: [ShopifyProviderModule],
+	providers: [FooService],
+})
+export class FooModule {}
+```
+
+Now inside of `FooService` you can use the `@InjectShopify()` decorator to get the `Shopify` instance
+
+```typescript
+// foo.service.ts
+import { InjectShopify } from '@juicyllama/app-shopify'
+import { Shopify } from '@shopify/shopify-api'
+
+@Injectable()
+export class FooService {
+	constructor(@InjectShopify() private readonly shopify: Shopify) {}
+
+	...
+}
+```


### PR DESCRIPTION
I've addressed the majority of the feedback I provided to Andy a few days back, including creating a Shopify provider that can be injected, removing several unnecessary module imports, and removing all of the `forwardRef` uses which cleans up how the injections look significantly.

There's a few things I'll point out in comments that we'll probably want to address before merging this, but hopefully this can be improved on in other apps as well.