### PR TITLE
refactor(everflow): update config dto name and reporting clicks module

### DIFF
--- a/apps/everflow/src/config/everflow.config.dto.ts
+++ b/apps/everflow/src/config/everflow.config.dto.ts
@@ -1,6 +1,6 @@
 import { IsString } from 'class-validator'
 
-export class everflowConfigDto {
+export class EverflowConfigDto {
 	@IsString()
 	EVERFLOW_API_KEY: string
 }

--- a/apps/everflow/src/config/everflow.config.joi.ts
+++ b/apps/everflow/src/config/everflow.config.joi.ts
@@ -1,5 +1,0 @@
-import Joi from 'joi'
-
-export const everflowConfigJoi = {
-	EVERFLOW_API_KEY: Joi.string(),
-}

--- a/apps/everflow/src/config/everflow.config.ts
+++ b/apps/everflow/src/config/everflow.config.ts
@@ -1,5 +1,5 @@
 import { registerAs } from '@nestjs/config'
-import { everflowConfigDto } from './everflow.config.dto'
+import { EverflowConfigDto } from './everflow.config.dto'
 import { RawAxiosRequestConfig } from 'axios'
 
 export default registerAs(
@@ -10,7 +10,7 @@ export default registerAs(
 		},
 )
 
-export function getEverflowAxiosConfig(config: everflowConfigDto): RawAxiosRequestConfig {
+export function getEverflowAxiosConfig(config: EverflowConfigDto): RawAxiosRequestConfig {
 	return {
 		headers: {
 			'Content-Type': 'application/json',

--- a/apps/everflow/src/config/everflow.config.ts
+++ b/apps/everflow/src/config/everflow.config.ts
@@ -1,14 +1,5 @@
-import { registerAs } from '@nestjs/config'
 import { EverflowConfigDto } from './everflow.config.dto'
 import { RawAxiosRequestConfig } from 'axios'
-
-export default registerAs(
-	'everflow',
-	() =>
-		<any>{
-			EVERFLOW_API_KEY: process.env.EVERFLOW_API_KEY,
-		},
-)
 
 export function getEverflowAxiosConfig(config: EverflowConfigDto): RawAxiosRequestConfig {
 	return {

--- a/apps/everflow/src/modules/affiliate/offers/everflow.affiliate.offers.service.test.spec.ts
+++ b/apps/everflow/src/modules/affiliate/offers/everflow.affiliate.offers.service.test.spec.ts
@@ -1,8 +1,6 @@
+import { Api, Env, Logger } from '@juicyllama/utils'
 import { Test, TestingModule } from '@nestjs/testing'
-import { Env } from '@juicyllama/utils'
 import { EverflowAffiliateOffersService } from './everflow.affiliate.offers.service'
-import { EverflowAffiliateOffersModule } from './everflow.affiliate.offers.module'
-import { forwardRef } from '@nestjs/common'
 
 describe('Affiliate Offers Service', () => {
 	let moduleRef: TestingModule
@@ -15,7 +13,22 @@ describe('Affiliate Offers Service', () => {
 		}
 
 		moduleRef = await Test.createTestingModule({
-			imports: [forwardRef(() => EverflowAffiliateOffersModule)],
+			providers: [
+				EverflowAffiliateOffersService,
+				{
+					provide: Api,
+					useValue: {
+						post: jest.fn(),
+					},
+				},
+				{
+					provide: Logger,
+					useValue: {
+						debug: jest.fn(),
+						error: jest.fn(),
+					},
+				},
+			],
 		}).compile()
 
 		everflowAffiliateOffersService = moduleRef.get<EverflowAffiliateOffersService>(EverflowAffiliateOffersService)

--- a/apps/everflow/src/modules/affiliate/offers/everflow.affiliate.offers.service.ts
+++ b/apps/everflow/src/modules/affiliate/offers/everflow.affiliate.offers.service.ts
@@ -3,7 +3,7 @@ import { Api, Logger, Env } from '@juicyllama/utils'
 import { ConfigService } from '@nestjs/config'
 import * as mock from '../../../types/offer/offers.mock.json'
 import { EverflowOffer } from '../../../types/offer/offer.dto'
-import { everflowConfigDto } from '../../../config/everflow.config.dto'
+import { EverflowConfigDto } from '../../../config/everflow.config.dto'
 import { getEverflowAxiosConfig } from '../../../config/everflow.config'
 
 const ENDPOINT = `https://api.eflow.team/v1/affiliates/alloffers`
@@ -16,7 +16,7 @@ export class EverflowAffiliateOffersService {
 		@Inject(forwardRef(() => ConfigService)) private readonly configService: ConfigService,
 	) {}
 
-	async findAllVisable(options: { config?: everflowConfigDto }): Promise<EverflowOffer[]> {
+	async findAllVisable(options: { config?: EverflowConfigDto }): Promise<EverflowOffer[]> {
 		const domain = 'app::everflow::affiliate::offers::findAllVisable'
 
 		if (Env.IsTest()) {

--- a/apps/everflow/src/modules/affiliate/offers/everflow.affiliate.offers.service.ts
+++ b/apps/everflow/src/modules/affiliate/offers/everflow.affiliate.offers.service.ts
@@ -1,19 +1,17 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common'
 import { Api, Logger, Env } from '@juicyllama/utils'
-import { ConfigService } from '@nestjs/config'
-import * as mock from '../../../types/offer/offers.mock.json'
-import { EverflowOffer } from '../../../types/offer/offer.dto'
+import { Injectable } from '@nestjs/common'
 import { EverflowConfigDto } from '../../../config/everflow.config.dto'
 import { getEverflowAxiosConfig } from '../../../config/everflow.config'
+import { EverflowOffer } from '../../../types/offer/offer.dto'
+import * as mock from '../../../types/offer/offers.mock.json'
 
 const ENDPOINT = `https://api.eflow.team/v1/affiliates/alloffers`
 
 @Injectable()
 export class EverflowAffiliateOffersService {
 	constructor(
-		@Inject(forwardRef(() => Api)) private readonly api: Api,
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
-		@Inject(forwardRef(() => ConfigService)) private readonly configService: ConfigService,
+		private readonly api: Api,
+		private readonly logger: Logger,
 	) {}
 
 	async findAllVisable(options: { config?: EverflowConfigDto }): Promise<EverflowOffer[]> {

--- a/apps/everflow/src/modules/affiliate/reporting/clicks/everflow.affiliate.reporting.clicks.module.ts
+++ b/apps/everflow/src/modules/affiliate/reporting/clicks/everflow.affiliate.reporting.clicks.module.ts
@@ -1,11 +1,8 @@
-import { ConfigValidationModule } from '@juicyllama/core'
 import { Api, Logger } from '@juicyllama/utils'
 import { Module } from '@nestjs/common'
-import { EverflowConfigDto } from '../../../../config/everflow.config.dto'
 import { EverflowAffiliateReportingClicksService } from './everflow.affiliate.reporting.clicks.service'
 
 @Module({
-	imports: [ConfigValidationModule.register(EverflowConfigDto)],
 	controllers: [],
 	providers: [EverflowAffiliateReportingClicksService, Logger, Api],
 	exports: [EverflowAffiliateReportingClicksService],

--- a/apps/everflow/src/modules/affiliate/reporting/clicks/everflow.affiliate.reporting.clicks.module.ts
+++ b/apps/everflow/src/modules/affiliate/reporting/clicks/everflow.affiliate.reporting.clicks.module.ts
@@ -1,19 +1,11 @@
+import { ConfigValidationModule } from '@juicyllama/core'
+import { Api, Logger } from '@juicyllama/utils'
 import { Module } from '@nestjs/common'
-import { ConfigModule } from '@nestjs/config'
-import { Api, Env, Logger } from '@juicyllama/utils'
-import Joi from 'joi'
+import { EverflowConfigDto } from '../../../../config/everflow.config.dto'
 import { EverflowAffiliateReportingClicksService } from './everflow.affiliate.reporting.clicks.service'
-import everflowConfig from '../../../../config/everflow.config'
-import { everflowConfigJoi } from '../../../../config/everflow.config.joi'
 
 @Module({
-	imports: [
-		ConfigModule.forRoot({
-			isGlobal: true,
-			load: [everflowConfig],
-			validationSchema: Env.IsNotTest() ? Joi.object(everflowConfigJoi) : null,
-		}),
-	],
+	imports: [ConfigValidationModule.register(EverflowConfigDto)],
 	controllers: [],
 	providers: [EverflowAffiliateReportingClicksService, Logger, Api],
 	exports: [EverflowAffiliateReportingClicksService],

--- a/apps/everflow/src/modules/affiliate/reporting/clicks/everflow.affiliate.reporting.clicks.service.test.spec.ts
+++ b/apps/everflow/src/modules/affiliate/reporting/clicks/everflow.affiliate.reporting.clicks.service.test.spec.ts
@@ -1,8 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { Env } from '@juicyllama/utils'
+import { Api, Env, Logger } from '@juicyllama/utils'
 import { EverflowAffiliateReportingClicksService } from './everflow.affiliate.reporting.clicks.service'
-import { EverflowAffiliateReportingClicksModule } from './everflow.affiliate.reporting.clicks.module'
-import { forwardRef } from '@nestjs/common'
 
 describe('Affiliate Reporting Clicks Service', () => {
 	let moduleRef: TestingModule
@@ -15,7 +13,22 @@ describe('Affiliate Reporting Clicks Service', () => {
 		}
 
 		moduleRef = await Test.createTestingModule({
-			imports: [forwardRef(() => EverflowAffiliateReportingClicksModule)],
+			providers: [
+				EverflowAffiliateReportingClicksService,
+				{
+					provide: Api,
+					useValue: {
+						post: jest.fn(),
+					},
+				},
+				{
+					provide: Logger,
+					useValue: {
+						debug: jest.fn(),
+						error: jest.fn(),
+					},
+				},
+			],
 		}).compile()
 
 		everflowAffiliateReportingClicksService = moduleRef.get<EverflowAffiliateReportingClicksService>(

--- a/apps/everflow/src/modules/affiliate/reporting/clicks/everflow.affiliate.reporting.clicks.service.ts
+++ b/apps/everflow/src/modules/affiliate/reporting/clicks/everflow.affiliate.reporting.clicks.service.ts
@@ -1,25 +1,23 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common'
 import { Api, Logger, Env } from '@juicyllama/utils'
-import { ConfigService } from '@nestjs/config'
+import { Injectable } from '@nestjs/common'
 import * as mock from '../../../../types/click/clicks.mock.json'
 import { EverflowClick } from '../../../../types/click/everflow.click.dto'
-import { EverflowAffiliateReportingClicksBody } from './everflow.affiliate.reporting.clicks.dto'
-import { everflowConfigDto } from '../../../../config/everflow.config.dto'
+import { EverflowConfigDto } from '../../../../config/everflow.config.dto'
 import { getEverflowAxiosConfig } from '../../../../config/everflow.config'
+import { EverflowAffiliateReportingClicksBody } from './everflow.affiliate.reporting.clicks.dto'
 
 const ENDPOINT = `https://api.eflow.team/v1/affiliates/reporting/clicks/stream`
 
 @Injectable()
 export class EverflowAffiliateReportingClicksService {
 	constructor(
-		@Inject(forwardRef(() => Api)) private readonly api: Api,
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
-		@Inject(forwardRef(() => ConfigService)) private readonly configService: ConfigService,
+		private readonly api: Api,
+		private readonly logger: Logger,
 	) {}
 
 	async findAll(options: {
 		arguments: EverflowAffiliateReportingClicksBody
-		config?: everflowConfigDto
+		config?: EverflowConfigDto
 	}): Promise<EverflowClick[]> {
 		const domain = 'app::everflow::affiliate::reporting::clicks::findAll'
 

--- a/apps/everflow/src/modules/affiliate/reporting/conversions/everflow.affiliate.reporting.conversions.module.ts
+++ b/apps/everflow/src/modules/affiliate/reporting/conversions/everflow.affiliate.reporting.conversions.module.ts
@@ -1,19 +1,8 @@
 import { Module } from '@nestjs/common'
-import { ConfigModule } from '@nestjs/config'
-import { Api, Env, Logger } from '@juicyllama/utils'
-import Joi from 'joi'
+import { Api, Logger } from '@juicyllama/utils'
 import { EverflowAffiliateReportingConversionsService } from './everflow.affiliate.reporting.conversions.service'
-import everflowConfig from '../../../../config/everflow.config'
-import { everflowConfigJoi } from '../../../../config/everflow.config.joi'
 
 @Module({
-	imports: [
-		ConfigModule.forRoot({
-			isGlobal: true,
-			load: [everflowConfig],
-			validationSchema: Env.IsNotTest() ? Joi.object(everflowConfigJoi) : null,
-		}),
-	],
 	controllers: [],
 	providers: [EverflowAffiliateReportingConversionsService, Logger, Api],
 	exports: [EverflowAffiliateReportingConversionsService],

--- a/apps/everflow/src/modules/affiliate/reporting/conversions/everflow.affiliate.reporting.conversions.service.test.spec.ts
+++ b/apps/everflow/src/modules/affiliate/reporting/conversions/everflow.affiliate.reporting.conversions.service.test.spec.ts
@@ -1,8 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing'
-import { Env } from '@juicyllama/utils'
+import { Api, Env, Logger } from '@juicyllama/utils'
 import { EverflowAffiliateReportingConversionsService } from './everflow.affiliate.reporting.conversions.service'
-import { EverflowAffiliateReportingConversionsModule } from './everflow.affiliate.reporting.conversions.module'
-import { forwardRef } from '@nestjs/common'
 
 describe('Affiliate Reporting Conversions Service', () => {
 	let moduleRef: TestingModule
@@ -15,7 +13,22 @@ describe('Affiliate Reporting Conversions Service', () => {
 		}
 
 		moduleRef = await Test.createTestingModule({
-			imports: [forwardRef(() => EverflowAffiliateReportingConversionsModule)],
+			providers: [
+				EverflowAffiliateReportingConversionsService,
+				{
+					provide: Api,
+					useValue: {
+						post: jest.fn(),
+					},
+				},
+				{
+					provide: Logger,
+					useValue: {
+						debug: jest.fn(),
+						error: jest.fn(),
+					},
+				},
+			],
 		}).compile()
 
 		everflowAffiliateReportingConversionsService = moduleRef.get<EverflowAffiliateReportingConversionsService>(

--- a/apps/everflow/src/modules/affiliate/reporting/conversions/everflow.affiliate.reporting.conversions.service.ts
+++ b/apps/everflow/src/modules/affiliate/reporting/conversions/everflow.affiliate.reporting.conversions.service.ts
@@ -1,6 +1,5 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common'
 import { Api, Logger, Env } from '@juicyllama/utils'
-import { ConfigService } from '@nestjs/config'
+import { Injectable } from '@nestjs/common'
 import * as mock from '../../../../types/conversion/conversions.mock.json'
 import { EverflowConfigDto } from '../../../../config/everflow.config.dto'
 import { getEverflowAxiosConfig } from '../../../../config/everflow.config'
@@ -12,9 +11,8 @@ const ENDPOINT = 'https://api.eflow.team/v1/affiliates/reporting/conversions'
 @Injectable()
 export class EverflowAffiliateReportingConversionsService {
 	constructor(
-		@Inject(forwardRef(() => Api)) private readonly api: Api,
-		@Inject(forwardRef(() => Logger)) private readonly logger: Logger,
-		@Inject(forwardRef(() => ConfigService)) private readonly configService: ConfigService,
+		private readonly api: Api,
+		private readonly logger: Logger,
 	) {}
 
 	async findAll(options: {

--- a/apps/everflow/src/modules/affiliate/reporting/conversions/everflow.affiliate.reporting.conversions.service.ts
+++ b/apps/everflow/src/modules/affiliate/reporting/conversions/everflow.affiliate.reporting.conversions.service.ts
@@ -2,7 +2,7 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common'
 import { Api, Logger, Env } from '@juicyllama/utils'
 import { ConfigService } from '@nestjs/config'
 import * as mock from '../../../../types/conversion/conversions.mock.json'
-import { everflowConfigDto } from '../../../../config/everflow.config.dto'
+import { EverflowConfigDto } from '../../../../config/everflow.config.dto'
 import { getEverflowAxiosConfig } from '../../../../config/everflow.config'
 import { EverflowConversion } from '../../../../types/conversion/conversion.dto'
 import { EverflowAffiliateReportingConversionBody } from './everflow.affiliate.reporting.conversion.dto'
@@ -19,7 +19,7 @@ export class EverflowAffiliateReportingConversionsService {
 
 	async findAll(options: {
 		arguments: EverflowAffiliateReportingConversionBody
-		config?: everflowConfigDto
+		config?: EverflowConfigDto
 	}): Promise<EverflowConversion[]> {
 		const domain = 'app::everflow::affiliate::reporting::conversions::findAll'
 

--- a/apps/everflow/src/modules/everflow.module.ts
+++ b/apps/everflow/src/modules/everflow.module.ts
@@ -1,22 +1,12 @@
-import { forwardRef, Module } from '@nestjs/common'
-import { ConfigModule } from '@nestjs/config'
-import { Env } from '@juicyllama/utils'
-import Joi from 'joi'
-import everflowConfig from '../config/everflow.config'
-import { everflowConfigJoi } from '../config/everflow.config.joi'
+import { Module } from '@nestjs/common'
 import { EverflowAffiliateReportingConversionsModule } from './affiliate/reporting/conversions/everflow.affiliate.reporting.conversions.module'
 import { EverflowAffiliateReportingClicksModule } from './affiliate/reporting/clicks/everflow.affiliate.reporting.clicks.module'
 import { EverflowAffiliateOffersModule } from './affiliate/offers/everflow.affiliate.offers.module'
 @Module({
 	imports: [
-		ConfigModule.forRoot({
-			isGlobal: true,
-			load: [everflowConfig],
-			validationSchema: Env.IsNotTest() ? Joi.object(everflowConfigJoi) : null,
-		}),
-		forwardRef(() => EverflowAffiliateReportingClicksModule),
-		forwardRef(() => EverflowAffiliateReportingConversionsModule),
-		forwardRef(() => EverflowAffiliateOffersModule),
+		EverflowAffiliateReportingClicksModule,
+		EverflowAffiliateReportingConversionsModule,
+		EverflowAffiliateOffersModule,
 	],
 })
 export class EverflowModule {}

--- a/apps/everflow/src/sandbox/sandbox.module.ts
+++ b/apps/everflow/src/sandbox/sandbox.module.ts
@@ -1,7 +1,8 @@
-import { forwardRef, Module } from '@nestjs/common'
+import { Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
 import { EverflowModule } from '../modules/everflow.module'
 
 @Module({
-	imports: [forwardRef(() => EverflowModule)],
+	imports: [EverflowModule, ConfigModule.forRoot()],
 })
 export class SandboxModule {}


### PR DESCRIPTION
Cleaned up the tests to properly use mocks, removed the multiple uses of `ConfigModule` and replaced it in the sandbox, removed all the unnecessary `forwardRef`s as well. 