### PR TITLE
Refactored createSSL at common/cli/helpers/ssl.ts to have correct execution flow

### DIFF
--- a/common/cli/helpers/doppler.ts
+++ b/common/cli/helpers/doppler.ts
@@ -69,7 +69,7 @@ async function sync() {
 export async function setupDoppler(project: JL) {
 	let authed = false
 
-	if (!fileExists(currentPath + '.env')) {
+	if (!fileExists(currentPath() + '.env')) {
 		cli_log(`Login to Doppler for fetching .env secrets`)
 		authed = await login(project)
 	}

--- a/common/cli/helpers/files.ts
+++ b/common/cli/helpers/files.ts
@@ -6,7 +6,7 @@ export enum File {
 	HOSTS = '/etc/hosts',
 }
 
-export const currentPath = process.cwd()
+export const currentPath = () => process.cwd()
 
 export function fileExists(location: string): boolean {
 	return fs.existsSync(location)

--- a/common/cli/helpers/ssl.ts
+++ b/common/cli/helpers/ssl.ts
@@ -25,7 +25,7 @@ async function createSSL(app: App) {
 }
 
 export async function setupSSL(app: App) {
-	const file = path.resolve(currentPath, app.ssl, `${app.domain}-key.pem`)
+	const file = path.join(currentPath(), app.ssl, `${app.domain}-key.pem`)
 
 	if (!fileExists(file)) {
 		await createSSL(app)

--- a/common/cli/helpers/ssl.ts
+++ b/common/cli/helpers/ssl.ts
@@ -1,19 +1,27 @@
-import { exec } from 'child_process'
+import path from 'path'
+import { exec } from 'child-process-promise'
+
+import { App } from '../types/apps'
+
 import { cli_error, cli_log } from './logging'
 import { currentPath, fileExists } from './files'
-import { App } from '../types/apps'
-import path from 'path'
 
 async function createSSL(app: App) {
 	cli_log(`Creating SSL certificate for ${app.domain}`)
-	const command = `current_dir=$PWD;cd $PWD/${app.ssl};mkcert ${app.domain};cd $current_dir;`
-	exec(command, async (error, stdout, stderr) => {
-		if (error) {
-			cli_error(`error: ${stderr} (${stdout})`)
-			return
-		}
+	const command = [
+		'current_dir=$PWD',
+		`cd $PWD/${app.ssl}`,
+		`mkcert ${app.domain}`,
+		'cd $current_dir',
+	].join('; ')
+
+	try {
+		await exec(command);
+
 		cli_log(`SSL certificate created for ${app.domain}`)
-	})
+	} catch (e) {
+		cli_error(`SSL certificate for ${app.domain} not created. Error: ${e.message}`);
+	}
 }
 
 export async function setupSSL(app: App) {


### PR DESCRIPTION
This change corrects the execution flow of the `createSSL()` function.

Earlier, it would return before executing the underlying command since [this](https://github.com/juicyllama/framework/blob/9a248ee9269c218db8a541d28bcae79fe1ee521b/common/cli/helpers/ssl.ts#L10) call is asynchronous but is not wrapped in an awaited promise (also `async` declaration of the callback does not have effect in this case).

The function will now return correctly after the underlying command has been executed.
It also allows rethrowing the error and handling it outside if desired.

---

Fixed `file` path generation in `setupSSL` check.
`path.resolve` did not return the assumed value in some cases:

e.g.
```js
> path.resolve('/juicyllama/client-abcd/backend', 'apps/api/src/assets', 'local.api.abcd.co-key.pem');
'/juicyllama/client-abcd/backend/apps/api/src/assets/local.api.abcd.co-key.pem'
```
is the same as
```js
> path.join('/juicyllama/client-abcd/backend', 'apps/api/src/assets', 'local.api.abcd.co-key.pem');
'/juicyllama/client-abcd/backend/apps/api/src/assets/local.api.abcd.co-key.pem'
```

**BUT**
```js
> path.resolve('/juicyllama/client-abcd/frontend', '/', 'local.app.abcd.co-key.pem');
'/local.app.abcd.co-key.pem'
```
when we expect the value to be
```js
> path.join('/juicyllama/client-abcd/frontend', '/', 'local.app.abcd.co-key.pem');
'/juicyllama/client-abcd/frontend/local.app.abcd.co-key.pem'
```

----

Changed the `currentPath` helper to function: the earlier value version would cache for the entire application execution and would not reflect changes, if any. It probably did not yet cause problems, but I decided to prevent a potential pitfall. 