### PR TITLE
use FormSchema name as form id

### DIFF
--- a/frontend/core/src/components/common/form/Form.vue
+++ b/frontend/core/src/components/common/form/Form.vue
@@ -56,17 +56,16 @@ function updatedField(value: string) {
 
 async function buttonPressed(button: FormCustomButton) {
 	logger({ severity: LogSeverity.VERBOSE, message: `Form Button Pressed`, object: button })
-	
-	if(button.type){
+
+	if (button.type) {
 		switch (button.type) {
 			case FormFieldButtonType.ACTION:
 				button.action({ button: button, formData: formData, schema: props.options, q: $q })
 				break
 		}
-	}else{
+	} else {
 		submittedForm()
 	}
-	
 }
 
 async function submittedForm() {
@@ -138,7 +137,7 @@ if (props.options.onFormLoad) {
 
 <template>
 	<div id="JLForm">
-		<q-form @submit="submittedForm" class="row">
+		<q-form :id="options.name" @submit="submittedForm" class="row">
 			<div
 				v-for="field in props.options?.fields"
 				:key="field.key"
@@ -160,9 +159,7 @@ if (props.options.onFormLoad) {
 					:class="`JLHTML JLHTML${Strings.capitalize(field.field)} JLHTML${Strings.capitalize(
 						field.key,
 					)} ${field.classes ?? ''}`"
-					v-html="field.value"
-					>
-				</div>
+					v-html="field.value"></div>
 
 				<q-input
 					v-if="field.field === FormFieldField.INPUT"
@@ -187,8 +184,8 @@ if (props.options.onFormLoad) {
 								? inputEmailRequired()
 								: inputEmailNotRequired()
 							: field.required
-							? inputRequired(field)
-							: null
+								? inputRequired(field)
+								: null
 					"
 					:loading="field.loading"
 					:disable="field.disabled"
@@ -209,7 +206,7 @@ if (props.options.onFormLoad) {
 					@keyup.enter="updatedField(field.key)"
 					@blur="updatedField(field.key)"></q-input>
 
-				<q-input 
+				<q-input
 					v-if="field.field === FormFieldField.TEXTAREA"
 					v-model="formData[field.key]"
 					:label="!field.settings?.stack_label ? field.label : null"
@@ -229,8 +226,8 @@ if (props.options.onFormLoad) {
 								? inputEmailRequired()
 								: inputEmailNotRequired()
 							: field.required
-							? inputRequired(field)
-							: null
+								? inputRequired(field)
+								: null
 					"
 					:loading="field.loading"
 					:disable="field.disabled"
@@ -251,7 +248,7 @@ if (props.options.onFormLoad) {
 					@keyup.enter="updatedField(field.key)"
 					@blur="updatedField(field.key)"></q-input>
 
-				<q-select 
+				<q-select
 					v-if="field.field === FormFieldField.DROPDOWN"
 					v-model="formData[field.key]"
 					:options="field.dropdown"
@@ -302,7 +299,7 @@ if (props.options.onFormLoad) {
 					</template>
 				</q-select>
 
-				<q-select 
+				<q-select
 					v-if="field.field === FormFieldField.COUNTRY_DROPDOWN"
 					v-model="formData[field.key]"
 					:options="countries"
@@ -350,7 +347,7 @@ if (props.options.onFormLoad) {
 					</template>
 				</q-select>
 
-				<q-select 
+				<q-select
 					v-if="field.field === FormFieldField.LANGUAGE_DROPDOWN"
 					v-model="formData[field.key]"
 					:options="languages"
@@ -442,7 +439,7 @@ if (props.options.onFormLoad) {
 					:field="field"
 					@installed="installedApp($event, field)" />
 
-				<q-input 
+				<q-input
 					v-if="field.field === FormFieldField.HIDDEN"
 					v-model="formData[field.key]"
 					:name="field.key"
@@ -458,7 +455,15 @@ if (props.options.onFormLoad) {
 							field.key,
 						)} ${field.classes ?? ''} ${button.classes ?? ''}`"
 						:key="key"
-						:color="(!button?.classes && !field.settings?.button_style?.classes) ? button.color ? button.color : field.settings?.button_style?.color ? field.settings?.button_style?.color : 'primary' : 'primary'"
+						:color="
+							!button?.classes && !field.settings?.button_style?.classes
+								? button.color
+									? button.color
+									: field.settings?.button_style?.color
+										? field.settings?.button_style?.color
+										: 'primary'
+								: 'primary'
+						"
 						:type="button?.type === FormFieldButtonType.SUBMIT ? 'submit' : 'button'"
 						:text-color="button?.text_color ?? field.settings?.button_style?.text_color ?? null"
 						:size="button?.size ?? field.settings?.button_style?.size ?? null"
@@ -507,12 +512,11 @@ if (props.options.onFormLoad) {
 					<div class="q-field__bottom row items-start q-field__bottom--animated">
 						<div class="q-field__messages col">
 							<div role="alert">
-								{{field.error}}
+								{{ field.error }}
 							</div>
 						</div>
 					</div>
 				</div>
-			
 			</div>
 		</q-form>
 	</div>


### PR DESCRIPTION
This improvement allow to create buttons or other field connected to that form

UseCase: 

Create a submit Button outside the form with `form propriety value  = form id (FormSchema.name)` to trigger submit

```
const formProject = {
		name: "project_detail_form",
		fields: [
			{
				key: 'project_name',
				label: 'Project Name',
				field: FormFieldField.INPUT,
				type: FormFieldType.TEXT,
				required: true,
				settings: formSettings?.field?.settings,
				hint: 'A name for your project, this will be used to identify your project in the dashboard.',
			},
		],
	}



<q-scroll-area style="height: 500px" class="pb-3">
  <JLForm class="!h-full" :options="formProject" @submittedForm="submitProject" />
</q-scroll-area>`
<q-separator />
<div class="w-full flex justify-end items-center mt-3">
  <q-btn label="Continue" color="primary" type="submit" form="project_detail_form" />
</div>
```