### PR TITLE
Utils: Fix ExtendsMultiple

### DIFF
--- a/common/utils/src/utils/Classes.test.spec.ts
+++ b/common/utils/src/utils/Classes.test.spec.ts
@@ -1,0 +1,129 @@
+import { Classes } from './Classes'
+
+// Example parent classes remain unchanged...
+
+// Example parent classes
+class ClassA {
+	name: string
+
+	constructor(name: string) {
+		this.name = name
+	}
+
+	greet(): string {
+		return `Hello from ClassA, ${this.name}`
+	}
+}
+
+class ClassB {
+	age: number
+
+	constructor(age: number) {
+		this.age = age
+	}
+
+	celebrate(): string {
+		return `Celebrating ${this.age} years`
+	}
+}
+
+class ClassC {
+	greeting: string
+
+	constructor(greeting: string) {
+		this.greeting = greeting
+	}
+
+	greet(): string {
+		return `ClassC says: ${this.greeting}`
+	}
+}
+
+class ClassD {
+	message: string
+
+	constructor(message: string) {
+		this.message = message
+	}
+
+	getMessage(): string {
+		return this.message
+	}
+
+	delayedGreet(): Promise<string> {
+		return new Promise(resolve => {
+			setTimeout(() => resolve(`Delayed Greet: ${this.getMessage()}`), 50)
+		})
+	}
+}
+
+class ClassE {
+	value: number
+
+	constructor(value: number) {
+		this.value = value
+	}
+
+	double(): number {
+		return this.value * 2
+	}
+}
+describe('Classes', () => {
+	describe('ExtendsMultiple', () => {
+		it('should inherit properties and methods from all parent classes', () => {
+			const MixedClass = Classes.ExtendsMultiple(ClassA, ClassB)
+			const mixedInstance = new MixedClass(['Test'], [30]) // Adjusted for wrapping arrays
+
+			expect(mixedInstance.greet()).toBe('Hello from ClassA, Test')
+			expect(mixedInstance.celebrate()).toBe('Celebrating 30 years')
+		})
+
+		it('should call constructors of all parent classes', () => {
+			const MixedClass = Classes.ExtendsMultiple(ClassA, ClassB)
+			const mixedInstance = new MixedClass(['Test'], [30]) // Adjusted for wrapping arrays
+
+			expect(mixedInstance.name).toBe('Test')
+			expect(mixedInstance.age).toBe(30)
+		})
+
+		it('should handle instanceof checks correctly for the most derived and base classes', () => {
+			const MixedClass = Classes.ExtendsMultiple(ClassA, ClassB)
+			const mixedInstance = new MixedClass(['Test'], [30]) // Adjusted for wrapping arrays
+
+			expect(mixedInstance instanceof MixedClass).toBe(true)
+		})
+
+		it('should properly handle methods with the same name', () => {
+			const MixedClass = Classes.ExtendsMultiple(ClassA, ClassC)
+			const mixedInstance = new MixedClass(['Test'], ['Hello']) // Adjusted for wrapping arrays
+
+			expect(mixedInstance.greet()).toBe('ClassC says: Hello')
+		})
+
+		it('should ensure proper binding of methods', async () => {
+			const MixedClass = Classes.ExtendsMultiple(ClassA, ClassD)
+			const mixedInstance = new MixedClass(['Test'], ['Async Hello']) // Adjusted for wrapping arrays
+
+			await expect(mixedInstance.delayedGreet()).resolves.toBe('Delayed Greet: Async Hello')
+		})
+
+		it('should integrate seamlessly with other functionalities', () => {
+			const MixedClass = Classes.ExtendsMultiple(ClassA, ClassE)
+			const mixedInstance = new MixedClass(['Test'], [15]) // Adjusted for wrapping arrays
+
+			expect(mixedInstance.double()).toBe(30)
+		})
+
+		it('should maintain distinct instances without shared state', () => {
+			const MixedClass = Classes.ExtendsMultiple(ClassA, ClassB)
+			const instance1 = new MixedClass(['Instance1'], [10]) // Adjusted for wrapping arrays
+			const instance2 = new MixedClass(['Instance2'], [20]) // Adjusted for wrapping arrays
+
+			instance1.name = 'ChangedName1'
+			instance2.age = 25
+
+			expect(instance1.name).not.toBe(instance2.name)
+			expect(instance1.age).not.toBe(instance2.age)
+		})
+	})
+})

--- a/common/utils/src/utils/Classes.ts
+++ b/common/utils/src/utils/Classes.ts
@@ -1,16 +1,45 @@
+type Constructor<T = {}> = new (...args: any[]) => T
+
+/**
+ * A utility class for working with classes.
+ */
 export class Classes {
 	/*
-	 * Allow classes to extend multiple classes
+	 * Allow classes to extend multiple classes. Returns a constructor with a mixed type of all base classes.
+	 * The constructor calls the constructors of all base classes and assigns their properties to the mixed class.
+	 * Each base class can have its own set of constructor arguments.
+	 * Example: `const MixedClass = Classes.ExtendsMultiple(ClassA, ClassB); const mixedInstance = new MixedClass(['Test'], [30])`
+	 * In this example, `mixedInstance` will have properties and methods from both `ClassA` and `ClassB`.
+	 * ClassA's constructor will be called with `['Test']` and ClassB's constructor with `[30]`.
+	 *
+	 * @param baseClasses The base classes to extend.
 	 */
-
-	static ExtendsMultiple(classes: any[]): any {
-		return classes.reduce((baseClass, cls) => {
-			return class extends baseClass {
-				constructor(...args: any[]) {
-					super(...args)
-					Object.assign(this, new cls(...args))
-				}
+	static ExtendsMultiple<TBase extends Constructor[]>(
+		...baseClasses: TBase
+	): new (...args: any[]) => UnionToIntersection<InstanceType<TBase[number]>> {
+		class BaseClass extends (baseClasses[0] || class {}) {
+			constructor(...args: any[]) {
+				super(...args[0]) // Assuming the first set of args is for the base class
+				// Call constructors of all mixins
+				baseClasses.slice(1).forEach((Base, index) => {
+					Object.assign(this, new Base(...args[index + 1]))
+				})
 			}
+		}
+
+		// Apply mixins
+		baseClasses.slice(1).forEach(baseClass => {
+			Object.getOwnPropertyNames(baseClass.prototype).forEach(name => {
+				const descriptor = Object.getOwnPropertyDescriptor(baseClass.prototype, name)
+				if (descriptor) {
+					Object.defineProperty(BaseClass.prototype, name, descriptor)
+				}
+			})
 		})
+
+		return BaseClass as any
 	}
 }
+
+// Helper type for converting a union of types to an intersection
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never


### PR DESCRIPTION
I took the liberty change the signature of the ExtendsMultiple from `ExtendsMultiple([classA,...])` to `ExtendsMultiple(classA, ...)`

Also decided that the output class's constructor will take each base class's args as an array e.g. `new mixedClass([argA1, argA2...], [argB1,...])`. Hope that makes sense. I tried various other approaches but they all ended up clashing somehow.